### PR TITLE
changes to get parentheses working in Fast Reader.

### DIFF
--- a/Code/Reader/Fast/read.lisp
+++ b/Code/Reader/Fast/read.lisp
@@ -858,8 +858,9 @@
 		       ((let ((type (syntax-type table char)))
 			  (or (eq type 'terminating-macro-char)
 			      (eq type 'non-terminating-macro-char)))
-			(funcall (get-macro-character char)
-                                 input-stream char))
+			(return-from read-upcase-downcase-preserve-decimal
+                          (funcall (get-macro-character char)
+                                   input-stream char)))
 		       (t
 			(error "don't know what this might be"))))
 	       (error "can't get here a"))

--- a/Code/Reader/Fast/test.lisp
+++ b/Code/Reader/Fast/test.lisp
@@ -699,3 +699,34 @@
 			   (/ (float -2 1s0) (float 10 1s0))))))))
 
 			      
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;
+;;; Reading parentheses
+
+(define-test read.parenthesis.list.empty
+  (let ((*read-base* 10)
+        (*readtable* (copy-readtable nil)))
+    (assert-equal nil
+                  (with-input-from-string (stream "()")
+                    (read stream)))))
+
+(define-test read.parenthesis.list.non.empty
+  (let ((*read-base* 10)
+        (*readtable* (copy-readtable nil)))
+    (assert-equal (list nil)
+                  (with-input-from-string (stream "(())")
+                    (read stream)))))
+
+(define-test read.parenthesis.list.nested
+  (let ((*read-base* 10)
+        (*readtable* (copy-readtable nil)))
+    (assert-equal (list (list nil))
+                  (with-input-from-string (stream "((()))")
+                    (read stream)))))
+
+(define-test read.parenthesis.list.non.empty.cdr
+  (let ((*read-base* 10)
+        (*readtable* (copy-readtable nil)))
+    (assert-equal (list nil nil)
+                  (with-input-from-string (stream "(()())")
+                    (read stream)))))


### PR DESCRIPTION
Parentheses as list delimiters appear to work now.  I have not yet tested other macro characters yet.