### PR TITLE
Fix sicl-loop-test system definition

### DIFF
--- a/Code/Loop/Test/sicl-loop-test.asd
+++ b/Code/Loop/Test/sicl-loop-test.asd
@@ -7,7 +7,6 @@
   ((:file "test-packages")
    (:file "loop-defmacro")
    (:file "loop-test")
-   (:file "simple-loop")
    (:file "loop1")
    (:file "loop2")
    (:file "loop3")


### PR DESCRIPTION
This removes a file that doesn't exist from the definition.