### PR TITLE
Distinguish string values from vector values transformed by quasiquote macro

### DIFF
--- a/Code/Reader/Simple/quasiquote-macro.lisp
+++ b/Code/Reader/Simple/quasiquote-macro.lisp
@@ -44,6 +44,8 @@
 	    (error 'undefined-use-of-backquote))
 	   (t
 	    `(append ,@(transform-compound argument)))))
+        ((stringp argument)
+         argument)
 	((vectorp argument)
 	 `(apply #'vector
 		 ,(transform-quasiquote-argument


### PR DESCRIPTION
This behaviour seems to be unexpected:

> \> (quasiquote "str")
#(#\s #\t #\r)

String arguments passed to `transform-quasiquote-arguments` satisfy `vectorp`, so are handled as vectors. Instead, passing through string values as in the patch yields:

> \> (quasiquote "str")
"str"
