### PR TITLE
cleavir-ast-to-source: fix loading of the system

### DIFF
--- a/Code/Cleavir/AST-to-source/accessors.lisp
+++ b/Code/Cleavir/AST-to-source/accessors.lisp
@@ -29,11 +29,13 @@
     ,(to-source (cleavir-ast:slot-number-ast ast) dictionary)
     ,(to-source (cleavir-ast:value-ast ast) dictionary)))
 
+#+ (or)
 (defmethod to-source ((ast cleavir-ast:aref-ast) dictionary)
   `(cleavir-primop:aref
     ,(to-source (cleavir-ast:array-ast ast) dictionary)
     ,(to-source (cleavir-ast:index-ast ast) dictionary)))
 
+#+ (or)
 (defmethod to-source ((ast cleavir-ast:aset-ast) dictionary)
   `(cleavir-primop:aset
     ,(to-source (cleavir-ast:array-ast ast) dictionary)

--- a/Code/Cleavir/AST-to-source/ast-to-source.lisp
+++ b/Code/Cleavir/AST-to-source/ast-to-source.lisp
@@ -57,6 +57,7 @@
 (defmethod to-source ((ast cleavir-ast:lexical-ast) dictionary)
   (cdr (assoc ast dictionary)))
 
+#+ (or)
 (defmethod to-source ((ast cleavir-ast:special-ast) dictionary)
   (cdr (assoc ast dictionary)))
 
@@ -65,6 +66,7 @@
 	    ,@(loop for arg in (cleavir-ast:argument-asts ast)
 		    collect (to-source arg dictionary))))
 
+#+ (or)
 (defmethod to-source ((ast cleavir-ast:global-ast) dictionary)
   `#',(cleavir-ast:name ast))
 

--- a/Code/Cleavir/AST-to-source/fixnum.lisp
+++ b/Code/Cleavir/AST-to-source/fixnum.lisp
@@ -1,34 +1,34 @@
 (cl:in-package #:cleavir-ast-to-source)
 
-(defmethod to-source ((ast cleavir-ast:fixnum-+-ast) dictionary)
+(defmethod to-source ((ast cleavir-ast:fixnum-add-ast) dictionary)
   `(cleavir-primop:fixnum-+
     ,(to-source (cleavir-ast:arg1-ast ast) dictionary)
     ,(to-source (cleavir-ast:arg2-ast ast) dictionary)
     ,(to-source (cleavir-ast:variable-ast ast) dictionary)))
 
-(defmethod to-source ((ast cleavir-ast:fixnum---ast) dictionary)
+(defmethod to-source ((ast cleavir-ast:fixnum-sub-ast) dictionary)
   `(cleavir-primop:fixnum--
     ,(to-source (cleavir-ast:arg1-ast ast) dictionary)
     ,(to-source (cleavir-ast:arg2-ast ast) dictionary)
     ,(to-source (cleavir-ast:variable-ast ast) dictionary)))
 
-(defmethod to-source ((ast cleavir-ast:fixnum-<-ast) dictionary)
-  `(cleavir-primop:fixnum-<
+(defmethod to-source ((ast cleavir-ast:fixnum-less-ast) dictionary)
+  `(cleavir-primop:fixnum-less
     ,(to-source (cleavir-ast:arg1-ast ast) dictionary)
     ,(to-source (cleavir-ast:arg2-ast ast) dictionary)))
 
-(defmethod to-source ((ast cleavir-ast:fixnum-<=-ast) dictionary)
-  `(cleavir-primop:fixnum-<=
+(defmethod to-source ((ast cleavir-ast:fixnum-not-greater-ast) dictionary)
+  `(cleavir-primop:fixnum-not-greater
     ,(to-source (cleavir-ast:arg1-ast ast) dictionary)
     ,(to-source (cleavir-ast:arg2-ast ast) dictionary)))
 
-(defmethod to-source ((ast cleavir-ast:fixnum->-ast) dictionary)
-  `(cleavir-primop:fixnum->
+(defmethod to-source ((ast cleavir-ast:fixnum-greater-ast) dictionary)
+  `(cleavir-primop:fixnum-greater
     ,(to-source (cleavir-ast:arg1-ast ast) dictionary)
     ,(to-source (cleavir-ast:arg2-ast ast) dictionary)))
 
-(defmethod to-source ((ast cleavir-ast:fixnum->=-ast) dictionary)
-  `(cleavir-primop:fixnum->=
+(defmethod to-source ((ast cleavir-ast:fixnum-not-less-ast) dictionary)
+  `(cleavir-primop:fixnum-not-less
     ,(to-source (cleavir-ast:arg1-ast ast) dictionary)
     ,(to-source (cleavir-ast:arg2-ast ast) dictionary)))
 


### PR DESCRIPTION
Removed non-existant ast specializations, fixed fixnum specialization
names and commented out aref/aset specializations[1].

[1] aref-ast, aset-ast are now more elaborate in cleavir - we have
t-*-ast, array-*-ast etc. These methods are not implemented for now.