### PR TITLE
internationalization: don't use obsolete nickname

### DIFF
--- a/Code/Cleavir/Environment/condition-reporters-english.lisp
+++ b/Code/Cleavir/Environment/condition-reporters-english.lisp
@@ -1,21 +1,21 @@
 (cl:in-package #:cleavir-environment)
 
-(defmethod cleavir-i18n:report-condition
-    ((condition no-variable-info) stream (langauge cleavir-i18n:english))
+(defmethod acclimation:report-condition
+    ((condition no-variable-info) stream (langauge acclimation:english))
   (let ((*package* (find-package '#:keyword)))
     (format stream "Undefined variable named ~s" (name condition))))
 
-(defmethod cleavir-i18n:report-condition
-    ((condition no-function-info) stream (langauge cleavir-i18n:english))
+(defmethod acclimation:report-condition
+    ((condition no-function-info) stream (langauge acclimation:english))
   (let ((*package* (find-package '#:keyword)))
     (format stream "Undefined function named ~s" (name condition))))
 
-(defmethod cleavir-i18n:report-condition
-    ((condition no-block-info) stream (langauge cleavir-i18n:english))
+(defmethod acclimation:report-condition
+    ((condition no-block-info) stream (langauge acclimation:english))
   (let ((*package* (find-package '#:keyword)))
     (format stream "Undefined block named ~s" (name condition))))
 
-(defmethod cleavir-i18n:report-condition
-    ((condition no-tag-info) stream (langauge cleavir-i18n:english))
+(defmethod acclimation:report-condition
+    ((condition no-tag-info) stream (langauge acclimation:english))
   (let ((*package* (find-package '#:keyword)))
     (format stream "Undefined tag named ~s" (name condition))))

--- a/Code/Cleavir/Environment/conditions.lisp
+++ b/Code/Cleavir/Environment/conditions.lisp
@@ -1,17 +1,17 @@
 (cl:in-package #:cleavir-environment)
 
 (define-condition no-variable-info
-    (program-error cleavir-i18n:condition)
+    (program-error acclimation:condition)
   ((%name :initarg :name :reader name)))
 
 (define-condition no-function-info
-    (program-error cleavir-i18n:condition)
+    (program-error acclimation:condition)
   ((%name :initarg :name :reader name)))
 
 (define-condition no-block-info
-    (program-error cleavir-i18n:condition)
+    (program-error acclimation:condition)
   ((%name :initarg :name :reader name)))
 
 (define-condition no-tag-info
-    (program-error cleavir-i18n:condition)
+    (program-error acclimation:condition)
   ((%name :initarg :name :reader name)))

--- a/Code/Cleavir/Generate-AST/condition-reporters-english.lisp
+++ b/Code/Cleavir/Generate-AST/condition-reporters-english.lisp
@@ -1,29 +1,29 @@
 (cl:in-package #:cleavir-generate-ast)
 
-(defmethod cleavir-i18n:report-condition
+(defmethod acclimation:report-condition
     ((condition block-name-must-be-a-symbol)
      stream
-     (langauge cleavir-i18n:english))
+     (langauge acclimation:english))
   (format stream
 	  "The name of a block must be a symbol,~@
            but the following was found instead:~@
            ~s"
 	  (expr condition)))
 
-(defmethod cleavir-i18n:report-condition
+(defmethod acclimation:report-condition
     ((condition situations-must-be-proper-list)
      stream
-     (langauge cleavir-i18n:english))
+     (langauge acclimation:english))
   (format stream
 	  "EVAL-WHEN situations must be a proper list,~@
            but the following was found instead:~@
            ~s"
 	  (expr condition)))
 
-(defmethod cleavir-i18n:report-condition
+(defmethod acclimation:report-condition
     ((condition invalid-eval-when-situation)
      stream
-     (langauge cleavir-i18n:english))
+     (langauge acclimation:english))
   (format stream
 	  "An EVAL-WHEN situation must be one of:~@
            :COMPILE-TOPLEVEL, :LOAD-TOPLEVEL, :EXECUTE, COMPILE, LOAD, EVAL,~@
@@ -31,30 +31,30 @@
            ~s"
 	  (expr condition)))
 
-(defmethod cleavir-i18n:report-condition
+(defmethod acclimation:report-condition
     ((condition flet-functions-must-be-proper-list)
      stream
-     (langauge cleavir-i18n:english))
+     (langauge acclimation:english))
   (format stream
 	  "The function definitions of an FLET form must be a proper list,~@
            but the following was found instead:~@
            ~s"
 	  (expr condition)))
 
-(defmethod cleavir-i18n:report-condition
+(defmethod acclimation:report-condition
     ((condition lambda-must-be-proper-list)
      stream
-     (langauge cleavir-i18n:english))
+     (langauge acclimation:english))
   (format stream
 	  "A LAMBDA expression must be a proper list,~@
            but the following was found instead:~@
            ~s"
 	  (expr condition)))
 
-(defmethod cleavir-i18n:report-condition
+(defmethod acclimation:report-condition
     ((condition function-argument-must-be-function-name-or-lambda-expression)
      stream
-     (langauge cleavir-i18n:english))
+     (langauge acclimation:english))
   (format stream
 	  "The argument of the special operator FUNCTION must be~@
            a function name or a LAMBDA expression,~@
@@ -62,30 +62,30 @@
            ~s"
 	  (expr condition)))
 
-(defmethod cleavir-i18n:report-condition
+(defmethod acclimation:report-condition
     ((condition bindings-must-be-proper-list)
      stream
-     (langauge cleavir-i18n:english))
+     (langauge acclimation:english))
   (format stream
 	  "The bindings of a LET or LET* special form must be a proper list,~@
            but the following was found instead:~@
            ~s"
 	  (expr condition)))
 
-(defmethod cleavir-i18n:report-condition
+(defmethod acclimation:report-condition
     ((condition binding-must-be-symbol-or-list)
      stream
-     (langauge cleavir-i18n:english))
+     (langauge acclimation:english))
   (format stream
 	  "A binding of a LET or LET* special form must be symbol or a list,~@
            but the following was found instead:~@
            ~s"
 	  (expr condition)))
 
-(defmethod cleavir-i18n:report-condition
+(defmethod acclimation:report-condition
     ((condition binding-must-have-length-one-or-two)
      stream
-     (langauge cleavir-i18n:english))
+     (langauge acclimation:english))
   (format stream
 	  "A binding of a LET or LET* special form that is a list,~@
            must be a proper list of length 1 or 2,~@
@@ -93,10 +93,10 @@
            ~s"
 	  (expr condition)))
 
-(defmethod cleavir-i18n:report-condition
+(defmethod acclimation:report-condition
     ((condition variable-must-be-a-symbol)
      stream
-     (langauge cleavir-i18n:english))
+     (langauge acclimation:english))
   (format stream
 	  "In a binding of a LET or LET* special form that is a list,~@
            the first element of that list must be a symbol,~@
@@ -104,10 +104,10 @@
            ~s"
 	  (expr condition)))
 
-(defmethod cleavir-i18n:report-condition
+(defmethod acclimation:report-condition
     ((condition read-only-p-must-be-boolean)
      stream
-     (langauge cleavir-i18n:english))
+     (langauge acclimation:english))
   (format stream
 	  "The second argument of a LOAD-TIME-VALUE special form,~@
            must be a Boolean constant (so T or NIL),~@
@@ -115,10 +115,10 @@
            ~s"
 	  (expr condition)))
 
-(defmethod cleavir-i18n:report-condition
+(defmethod acclimation:report-condition
     ((condition block-name-unknown)
      stream
-     (langauge cleavir-i18n:english))
+     (langauge acclimation:english))
   (format stream
 	  "In a RETURN or RETURN-FROM special form, the block name given~@
            must have been established by a BLOCK special form,~@
@@ -126,40 +126,40 @@
            ~s"
 	  (expr condition)))
 
-(defmethod cleavir-i18n:report-condition
+(defmethod acclimation:report-condition
     ((condition setq-must-have-even-number-of-arguments)
      stream
-     (langauge cleavir-i18n:english))
+     (langauge acclimation:english))
   (format stream
 	  "The SETQ special form must have an even number of arguments,~@
            but the following was found instead:~@
            ~s"
 	  (expr condition)))
 
-(defmethod cleavir-i18n:report-condition
+(defmethod acclimation:report-condition
     ((condition setq-var-must-be-symbol)
      stream
-     (langauge cleavir-i18n:english))
+     (langauge acclimation:english))
   (format stream
 	  "The variable assigned to in a SETQ special form must be a symbol,~@
            but the following was found instead:~@
            ~s"
 	  (expr condition)))
 
-(defmethod cleavir-i18n:report-condition
+(defmethod acclimation:report-condition
     ((condition setq-constant-variable)
      stream
-     (langauge cleavir-i18n:english))
+     (langauge acclimation:english))
   (format stream
 	  "The variable assigned to in a SETQ must not be a constant variable,~@
            but the following constant variable was found:~@
            ~s"
 	  (expr condition)))
 
-(defmethod cleavir-i18n:report-condition
+(defmethod acclimation:report-condition
     ((condition variable-name-unknown)
      stream
-     (langauge cleavir-i18n:english))
+     (langauge acclimation:english))
   (format stream
 	  "A variable referred to must have been previously defined,~@
            using either some global operator such as DEFVAR or DEFPARAMETER,~@
@@ -168,10 +168,10 @@
            ~s"
 	  (expr condition)))
 
-(defmethod cleavir-i18n:report-condition
+(defmethod acclimation:report-condition
     ((condition function-name-unknown)
      stream
-     (langauge cleavir-i18n:english))
+     (langauge acclimation:english))
   (format stream
 	  "A function referred to must have been previously defined,~@
            using either some global operator such as DEFUN or DEFGENERIC,~@
@@ -180,10 +180,10 @@
            ~s"
 	  (expr condition)))
 
-(defmethod cleavir-i18n:report-condition
+(defmethod acclimation:report-condition
     ((condition function-name-names-global-macro)
      stream
-     (langauge cleavir-i18n:english))
+     (langauge acclimation:english))
   (format stream
 	  "A function name was found in a context where the name~@
            must refer to a global or a local function, but the~@
@@ -191,10 +191,10 @@
            ~s"
 	  (expr condition)))
 
-(defmethod cleavir-i18n:report-condition
+(defmethod acclimation:report-condition
     ((condition function-name-names-local-macro)
      stream
-     (langauge cleavir-i18n:english))
+     (langauge acclimation:english))
   (format stream
 	  "A function name was found in a context where the name~@
            must refer to a global or a local function, but the~@
@@ -202,10 +202,10 @@
            ~s"
 	  (expr condition)))
 
-(defmethod cleavir-i18n:report-condition
+(defmethod acclimation:report-condition
     ((condition function-name-names-special-operator)
      stream
-     (langauge cleavir-i18n:english))
+     (langauge acclimation:english))
   (format stream
 	  "A function name was found in a context where the name~@
            must refer to a global or a local function, but the~@
@@ -213,10 +213,10 @@
            ~s"
 	  (expr condition)))
 
-(defmethod cleavir-i18n:report-condition
+(defmethod acclimation:report-condition
     ((condition no-default-method)
      stream
-     (langauge cleavir-i18n:english))
+     (langauge acclimation:english))
   (format stream
 	  "Cleavir does not supply methods for compiling every special operator.~@
            In particular, no default method is supplied for the following:~@

--- a/Code/Cleavir/Generate-AST/conditions.lisp
+++ b/Code/Cleavir/Generate-AST/conditions.lisp
@@ -5,15 +5,15 @@
 ;;; The base classes for conditions used here. 
 
 (define-condition compilation-program-error
-    (program-error cleavir-i18n:condition)
+    (program-error acclimation:condition)
   ((%expr :initarg :expr :reader expr)))
 
 (define-condition compilation-warning
-    (warning cleavir-i18n:condition)
+    (warning acclimation:condition)
   ((%expr :initarg :expr :reader expr)))
 
 (define-condition compilation-style-warning
-    (cleavir-i18n:condition style-warning)
+    (acclimation:condition style-warning)
   ((%expr :initarg :expr :reader expr)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/Code/Conditionals/condition-reporters-en.lisp
+++ b/Code/Conditionals/condition-reporters-en.lisp
@@ -31,27 +31,27 @@
 
 (cl:in-package :sicl-conditionals)
 
-(defmethod cleavir-i18n:report-condition ((condition malformed-body)
+(defmethod acclimation:report-condition ((condition malformed-body)
 					  stream
-					  (language cleavir-i18n:english))
+					  (language acclimation:english))
   (format stream
           "Expected a proper list of forms,~@
            but the following was given instead:~@
            ~s"
 	  (body condition)))
 
-(defmethod cleavir-i18n:report-condition ((condition malformed-cond-clauses)
+(defmethod acclimation:report-condition ((condition malformed-cond-clauses)
 					  stream
-					  (language cleavir-i18n:english))
+					  (language acclimation:english))
   (format stream
           "Expected a proper list of cond clauses,~@
            but the following was given instead:~@
            ~s"
 	  (clauses condition)))
 
-(defmethod cleavir-i18n:report-condition ((condition malformed-cond-clause)
+(defmethod acclimation:report-condition ((condition malformed-cond-clause)
 					  stream
-					  (language cleavir-i18n:english))
+					  (language acclimation:english))
   (format stream
 	  "Expected a cond clause of the form,~@
            (test-form form*),~@
@@ -59,18 +59,18 @@
            ~s"
 	  (clause condition)))
 
-(defmethod cleavir-i18n:report-condition ((condition malformed-case-clauses)
+(defmethod acclimation:report-condition ((condition malformed-case-clauses)
 					  stream
-					  (language cleavir-i18n:english))
+					  (language acclimation:english))
   (format stream
           "Expected a proper list of case clauses,~@
            but the following was given instead:~@
            ~s"
 	  (clauses condition)))
 
-(defmethod cleavir-i18n:report-condition ((condition malformed-case-clause)
+(defmethod acclimation:report-condition ((condition malformed-case-clause)
 					  stream
-					  (language cleavir-i18n:english))
+					  (language acclimation:english))
   (format stream
 	  "Expected a case clause of the form,~@
            (keys form*),~@
@@ -78,36 +78,36 @@
            ~s"
 	  (clause condition)))
 
-(defmethod cleavir-i18n:report-condition ((condition otherwise-clause-not-last)
+(defmethod acclimation:report-condition ((condition otherwise-clause-not-last)
 					  stream
-					  (language cleavir-i18n:english))
+					  (language acclimation:english))
   (format stream
 	  "The `otherwise' or `t' clause must be last in a case form,~@
            but but it was followed by:~@
            ~s"
 	  (clauses condition)))
 
-(defmethod cleavir-i18n:report-condition ((condition malformed-keys)
+(defmethod acclimation:report-condition ((condition malformed-keys)
 					  stream
-					  (language cleavir-i18n:english))
+					  (language acclimation:english))
   (format stream
 	  "Expected a designator for a list of keys,~@
            but the following was given instead:~@
            ~s"
 	  (keys condition)))
 
-(defmethod cleavir-i18n:report-condition ((condition malformed-typecase-clauses)
+(defmethod acclimation:report-condition ((condition malformed-typecase-clauses)
 					  stream
-					  (language cleavir-i18n:english))
+					  (language acclimation:english))
   (format stream
 	  "Expected a proper list of typecase clauses,~@
            but the following was given instead:~@
            ~s"
 	  (clauses condition)))
 
-(defmethod cleavir-i18n:report-condition ((condition malformed-typecase-clause)
+(defmethod acclimation:report-condition ((condition malformed-typecase-clause)
 					  stream
-					  (language cleavir-i18n:english))
+					  (language acclimation:english))
   (format stream
 	  "Expected a typecase clause of the form,~@
 	  (type form*),~@
@@ -119,9 +119,9 @@
 ;;;
 ;;; Conditions used at runtime
 
-(defmethod cleavir-i18n:report-condition ((condition ecase-type-error)
+(defmethod acclimation:report-condition ((condition ecase-type-error)
 					  stream
-					  (language cleavir-i18n:english))
+					  (language acclimation:english))
   (format stream
 	  "No key matched in ecase expression.~@
            Offending datum:~@
@@ -131,9 +131,9 @@
           (type-error-datum condition)
 	  (type-error-expected-type condition)))
 
-(defmethod cleavir-i18n:report-condition ((condition ccase-type-error)
+(defmethod acclimation:report-condition ((condition ccase-type-error)
 					  stream
-					  (language cleavir-i18n:english))
+					  (language acclimation:english))
   (format stream
 	  "No key matched in ccase expression.~@
            Offending datum:~@
@@ -143,9 +143,9 @@
           (type-error-datum condition)
 	  (type-error-expected-type condition)))
 
-(defmethod cleavir-i18n:report-condition ((condition etypecase-type-error)
+(defmethod acclimation:report-condition ((condition etypecase-type-error)
 					  stream
-					  (language cleavir-i18n:english))
+					  (language acclimation:english))
   (format stream
 	  "No key matched in etypecase expression.~@
            Offending datum:~@
@@ -155,9 +155,9 @@
           (type-error-datum condition)
 	  (type-error-expected-type condition)))
 
-(defmethod cleavir-i18n:report-condition ((condition ctypecase-type-error)
+(defmethod acclimation:report-condition ((condition ctypecase-type-error)
 					  stream
-					  (language cleavir-i18n:english))
+					  (language acclimation:english))
   (format stream
 	  "No key matched in ctypecase expression.~@
            Offending datum:~@

--- a/Code/Conditionals/conditions.lisp
+++ b/Code/Conditionals/conditions.lisp
@@ -46,39 +46,39 @@
   ((%name :initarg :name :reader name)))
 
 (define-condition malformed-body
-    (program-error name-mixin cleavir-i18n:condition)
+    (program-error name-mixin acclimation:condition)
   ((%body :initarg :body :reader body)))
      
 (define-condition malformed-cond-clauses
-    (program-error name-mixin cleavir-i18n:condition)
+    (program-error name-mixin acclimation:condition)
   ((%clauses :initarg :clauses :reader clauses)))
      
 (define-condition malformed-cond-clause
-    (program-error name-mixin cleavir-i18n:condition)
+    (program-error name-mixin acclimation:condition)
   ((%clause :initarg :clause :reader clause)))
      
 (define-condition malformed-case-clauses
-    (program-error name-mixin cleavir-i18n:condition)
+    (program-error name-mixin acclimation:condition)
   ((%clauses :initarg :clauses :reader clauses)))
      
 (define-condition malformed-case-clause
-    (program-error name-mixin cleavir-i18n:condition)
+    (program-error name-mixin acclimation:condition)
   ((%clause :initarg :clause :reader clause)))
      
 (define-condition otherwise-clause-not-last
-    (program-error name-mixin cleavir-i18n:condition)
+    (program-error name-mixin acclimation:condition)
   ((%clauses :initarg :clauses :reader clauses)))
 
 (define-condition malformed-keys
-    (program-error name-mixin cleavir-i18n:condition)
+    (program-error name-mixin acclimation:condition)
   ((%keys :initarg :keys :reader keys)))
      
 (define-condition malformed-typecase-clauses
-    (program-error name-mixin cleavir-i18n:condition)
+    (program-error name-mixin acclimation:condition)
   ((%clauses :initarg :clauses :reader clauses)))
      
 (define-condition malformed-typecase-clause
-    (program-error name-mixin cleavir-i18n:condition)
+    (program-error name-mixin acclimation:condition)
   ((%clause :initarg :clause :reader clause)))
      
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -86,17 +86,17 @@
 ;;; Conditions used at runtime
 
 (define-condition ecase-type-error
-    (type-error name-mixin cleavir-i18n:condition)
+    (type-error name-mixin acclimation:condition)
   ())
 
 (define-condition ccase-type-error
-    (type-error name-mixin cleavir-i18n:condition)
+    (type-error name-mixin acclimation:condition)
   ())
 
 (define-condition etypecase-type-error
-    (type-error name-mixin cleavir-i18n:condition)
+    (type-error name-mixin acclimation:condition)
   ())
 
 (define-condition ctypecase-type-error
-    (type-error name-mixin cleavir-i18n:condition)
+    (type-error name-mixin acclimation:condition)
   ())

--- a/Code/Conditions/Additional/condition-reporters-en.lisp
+++ b/Code/Conditions/Additional/condition-reporters-en.lisp
@@ -32,8 +32,8 @@
 	(t
 	 (format nil "an object of type ~s" type))))
 
-(defmethod cleavir-i18n:report-condition
-    ((c sicl-type-error) stream (language cleavir-i18n:english))
+(defmethod acclimation:report-condition
+    ((c sicl-type-error) stream (language acclimation:english))
   (format stream
 	  "Expected ~a.~@
 	   But got the following instead:~@
@@ -41,25 +41,25 @@
 	  (interpret-type (type-error-expected-type c))
 	  (type-error-datum c)))
 
-(defmethod cleavir-i18n:report-condition
-    ((c both-test-and-test-not-given) stream (language cleavir-i18n:english))
+(defmethod acclimation:report-condition
+    ((c both-test-and-test-not-given) stream (language acclimation:english))
   (format stream
 	  "Both keyword arguments :test and :test-not were given."))
 
-(defmethod cleavir-i18n:report-condition
-    ((c at-least-one-list-required) stream (language cleavir-i18n:english))
+(defmethod acclimation:report-condition
+    ((c at-least-one-list-required) stream (language acclimation:english))
   (format stream
 	  "At least one list argument is required,~@
            but none was given."))
 	  
-(defmethod cleavir-i18n:report-condition
-    ((c at-least-one-argument-required) stream (language cleavir-i18n:english))
+(defmethod acclimation:report-condition
+    ((c at-least-one-argument-required) stream (language acclimation:english))
   (format stream
 	  "At least one argument is required,~@
            but none was given."))
 	  
-(defmethod cleavir-i18n:report-condition
-    ((c lists-must-have-the-same-length) stream (language cleavir-i18n:english))
+(defmethod acclimation:report-condition
+    ((c lists-must-have-the-same-length) stream (language acclimation:english))
   (format stream
 	  "The two lists passed as arguments must~@
            have the same length, but the following~@
@@ -70,19 +70,19 @@
 	  (list1 c)
 	  (list2 c)))
 
-(defmethod cleavir-i18n:report-condition
-    ((c warn-both-test-and-test-not-given) stream (language cleavir-i18n:english))
+(defmethod acclimation:report-condition
+    ((c warn-both-test-and-test-not-given) stream (language acclimation:english))
   (format stream
 	  "Both keyword arguments :test and :test-not were given."))
 
-(defmethod cleavir-i18n:report-condition
-    ((c sicl-unbound-variable) stream (language cleavir-i18n:english))
+(defmethod acclimation:report-condition
+    ((c sicl-unbound-variable) stream (language acclimation:english))
   (format stream
 	  "The variable named ~s in unbound."
 	  (cell-error-name c)))
 
-(defmethod cleavir-i18n:report-condition
-    ((c sicl-undefined-function) stream (language cleavir-i18n:english))
+(defmethod acclimation:report-condition
+    ((c sicl-undefined-function) stream (language acclimation:english))
   (format stream
 	  "The funcation named ~s in undefined."
 	  (cell-error-name c)))
@@ -91,68 +91,68 @@
 ;;;
 ;;; Compile time conditions. 
 
-(defmethod cleavir-i18n:report-condition
-    ((c form-must-be-proper-list) stream (language cleavir-i18n:english))
+(defmethod acclimation:report-condition
+    ((c form-must-be-proper-list) stream (language acclimation:english))
   (format stream
 	  "A form must be a proper list.~@
            But the following was found instead:~@
            ~s"
 	  (code c)))
 
-(defmethod cleavir-i18n:report-condition
-    ((c body-must-be-proper-list) stream (language cleavir-i18n:english))
+(defmethod acclimation:report-condition
+    ((c body-must-be-proper-list) stream (language acclimation:english))
   (format stream
 	  "A code body must be a proper list.~@
            But the following was found instead:~@
            ~s"
 	  (code c)))
 
-(defmethod cleavir-i18n:report-condition
-    ((c block-tag-must-be-symbol) stream (language cleavir-i18n:english))
+(defmethod acclimation:report-condition
+    ((c block-tag-must-be-symbol) stream (language acclimation:english))
   (format stream
 	  "A block tag must be a symbol.~@
            But the following was found instead:~@
            ~s"
 	  (code c)))
 
-(defmethod cleavir-i18n:report-condition
-    ((c go-tag-must-be-symbol-or-integer) stream (language cleavir-i18n:english))
+(defmethod acclimation:report-condition
+    ((c go-tag-must-be-symbol-or-integer) stream (language acclimation:english))
   (format stream
 	  "A GO tag must be a symbol or an integer.~@
            But the following was found instead:~@
            ~s"
 	  (code c)))
 
-(defmethod cleavir-i18n:report-condition
-    ((c multiple-documentation-strings-in-body) stream (language cleavir-i18n:english))
+(defmethod acclimation:report-condition
+    ((c multiple-documentation-strings-in-body) stream (language acclimation:english))
   (format stream
 	  "Multiple documentation strings found in code body:~@
            ~s"
 	  (code c)))
 
-(defmethod cleavir-i18n:report-condition
-    ((c documentation-string-not-allowed-in-body) stream (language cleavir-i18n:english))
+(defmethod acclimation:report-condition
+    ((c documentation-string-not-allowed-in-body) stream (language acclimation:english))
   (format stream
 	  "A documentation string was found where none is allowed:~@
            ~s"
 	  (code c)))
 
-(defmethod cleavir-i18n:report-condition
-    ((c declarations-not-allowed-in-body) stream (language cleavir-i18n:english))
+(defmethod acclimation:report-condition
+    ((c declarations-not-allowed-in-body) stream (language acclimation:english))
   (format stream
 	  "Declarations found where none is allowed:~@
            ~s"
 	  (code c)))
 
-(defmethod cleavir-i18n:report-condition
-    ((c declaration-follows-form-in-body) stream (language cleavir-i18n:english))
+(defmethod acclimation:report-condition
+    ((c declaration-follows-form-in-body) stream (language acclimation:english))
   (format stream
 	  "Declarations can not follow the forms in a code body:~@
            ~s"
 	  (code c)))
 
-(defmethod cleavir-i18n:report-condition
-    ((c form-too-short) stream (language cleavir-i18n:english))
+(defmethod acclimation:report-condition
+    ((c form-too-short) stream (language acclimation:english))
   (format stream
 	  "The form:~@
            ~s~@
@@ -161,8 +161,8 @@
 	  (min-length c)
 	  (length (code c))))
 
-(defmethod cleavir-i18n:report-condition
-    ((c form-too-long) stream (language cleavir-i18n:english))
+(defmethod acclimation:report-condition
+    ((c form-too-long) stream (language acclimation:english))
   (format stream
 	  "The form:~@
            ~s~@
@@ -171,65 +171,65 @@
 	  (max-length c)
 	  (length (code c))))
 
-(defmethod cleavir-i18n:report-condition
-    ((c unknown-eval-when-situation) stream (language cleavir-i18n:english))
+(defmethod acclimation:report-condition
+    ((c unknown-eval-when-situation) stream (language acclimation:english))
   (format stream
 	  "Unknown evaluation situation given:~@
            ~s"
 	  (code c)))
 
-(defmethod cleavir-i18n:report-condition
-    ((c deprecated-eval-when-situation) stream (language cleavir-i18n:english))
+(defmethod acclimation:report-condition
+    ((c deprecated-eval-when-situation) stream (language acclimation:english))
   (format stream
 	  "A deprecated evaluation situation given:~@
            ~s"
 	  (code c)))
 
-(defmethod cleavir-i18n:report-condition
-    ((c setq-must-have-even-number-arguments) stream (language cleavir-i18n:english))
+(defmethod acclimation:report-condition
+    ((c setq-must-have-even-number-arguments) stream (language acclimation:english))
   (format stream
 	  "An even number of arguments are required.~@
            But the following was found instead:~@
            ~s"
 	  (code c)))
 
-(defmethod cleavir-i18n:report-condition
-    ((c setq-variable-must-be-symbol) stream (language cleavir-i18n:english))
+(defmethod acclimation:report-condition
+    ((c setq-variable-must-be-symbol) stream (language acclimation:english))
   (format stream
 	  "A variable assigned to must be a symbol.~@
            But the following was found instead:~@
            ~s"
 	  (code c)))
 
-(defmethod cleavir-i18n:report-condition
+(defmethod acclimation:report-condition
     ((c tagbody-element-must-be-symbol-integer-or-compound-form)
      stream
-     (language cleavir-i18n:english))
+     (language acclimation:english))
   (format stream
 	  "Element must be a symbol, an integer, or a compound form.~@
            But the following was found instead:~@
            ~s"
 	  (code c)))
 
-(defmethod cleavir-i18n:report-condition
-    ((c empty-body) stream (language cleavir-i18n:english))
+(defmethod acclimation:report-condition
+    ((c empty-body) stream (language acclimation:english))
   (format stream
 	  "The body of this form is empty:~@
            ~s"
 	  (code c)))
 
-(defmethod cleavir-i18n:report-condition
-    ((c numeric-catch-tag) stream (language cleavir-i18n:english))
+(defmethod acclimation:report-condition
+    ((c numeric-catch-tag) stream (language acclimation:english))
   (format stream
 	  "CATCH tags are compared with EQ so using a numeric~@
            CATCH tag may not work as expected:~@
            ~s"
 	  (code c)))
 
-(defmethod cleavir-i18n:report-condition
+(defmethod acclimation:report-condition
     ((c load-time-value-read-only-p-not-evaluated)
      stream
-     (language cleavir-i18n:english))
+     (language acclimation:english))
   (format stream
 	  "The second (optional) argument (read-only-p) is not evaluated,~@
            so a boolean value (T or NIL) was expected.~@
@@ -241,190 +241,190 @@
 ;;;
 ;;; CLOS/MOP-related conditions.
 
-(defmethod cleavir-i18n:report-condition  ((c no-such-class-name)
+(defmethod acclimation:report-condition  ((c no-such-class-name)
 			      stream
-			      (language cleavir-i18n:english))
+			      (language acclimation:english))
   (format stream
 	  "There is no class with the name ~s."
 	  (type-error-datum c)))
 
-(defmethod cleavir-i18n:report-condition  ((c must-be-class-or-nil)
+(defmethod acclimation:report-condition  ((c must-be-class-or-nil)
 			      stream
-			      (language cleavir-i18n:english))
+			      (language acclimation:english))
   (format stream
 	  "A class object or NIL was expected, but
            ~s was found."
 	  (type-error-datum c)))
 
-(defmethod cleavir-i18n:report-condition ((c superclass-list-must-be-proper-list)
+(defmethod acclimation:report-condition ((c superclass-list-must-be-proper-list)
 			     stream
-			     (language cleavir-i18n:english))
+			     (language acclimation:english))
   (format stream
 	  "The list of superclasses must be a proper list, but~@
            ~s was found."
 	  (type-error-datum c)))
 
-(defmethod cleavir-i18n:report-condition ((c class-name-must-be-non-nil-symbol)
+(defmethod acclimation:report-condition ((c class-name-must-be-non-nil-symbol)
 			     stream
-			     (language cleavir-i18n:english))
+			     (language acclimation:english))
   (format stream
 	  "A class name must be a non-nil symbol, but~@
            ~s was found."
 	  (type-error-datum c)))
 
-(defmethod cleavir-i18n:report-condition ((c malformed-slots-list)
+(defmethod acclimation:report-condition ((c malformed-slots-list)
 			     stream
-			     (language cleavir-i18n:english))
+			     (language acclimation:english))
   (format stream
 	  "The direct-slots must be a proper list of slot specs, but~@
            ~s was found."
 	  (type-error-datum c)))
 
-(defmethod cleavir-i18n:report-condition ((c malformed-slot-spec)
+(defmethod acclimation:report-condition ((c malformed-slot-spec)
 			     stream
-			     (language cleavir-i18n:english))
+			     (language acclimation:english))
   (format stream
 	  "Malformed slot specification.~@
            ~s was found."
 	  (type-error-datum c)))
 
-(defmethod cleavir-i18n:report-condition ((c illegal-slot-name)
+(defmethod acclimation:report-condition ((c illegal-slot-name)
 			     stream
-			     (language cleavir-i18n:english))
+			     (language acclimation:english))
   (format stream
 	  "Illegal slot name~@
            ~s was found."
 	  (type-error-datum c)))
 
-(defmethod cleavir-i18n:report-condition ((c slot-options-must-be-even)
+(defmethod acclimation:report-condition ((c slot-options-must-be-even)
 			     stream
-			     (language cleavir-i18n:english))
+			     (language acclimation:english))
   (format stream
 	  "There must be an even number of slot options.~@
            ~s was found."
 	  (type-error-datum c)))
 
-(defmethod cleavir-i18n:report-condition ((c slot-option-name-must-be-symbol)
+(defmethod acclimation:report-condition ((c slot-option-name-must-be-symbol)
 			     stream
-			     (language cleavir-i18n:english))
+			     (language acclimation:english))
   (format stream
 	  "The name of a slot option must be a symbol, but~@
            ~s was found."
 	  (type-error-datum c)))
 
-(defmethod cleavir-i18n:report-condition ((c multiple-initform-options-not-permitted)
+(defmethod acclimation:report-condition ((c multiple-initform-options-not-permitted)
 			     stream
-			     (language cleavir-i18n:english))
+			     (language acclimation:english))
   (format stream
 	  "A slot can not have multiple :initform options.~@
            ~s was found."
 	  (type-error-datum c)))
 
-(defmethod cleavir-i18n:report-condition ((c multiple-documentation-options-not-permitted)
+(defmethod acclimation:report-condition ((c multiple-documentation-options-not-permitted)
 			     stream
-			     (language cleavir-i18n:english))
+			     (language acclimation:english))
   (format stream
 	  "A slot can not have multiple :documentation options.~@
            ~s was found."
 	  (type-error-datum c)))
 
-(defmethod cleavir-i18n:report-condition ((c multiple-allocation-options-not-permitted)
+(defmethod acclimation:report-condition ((c multiple-allocation-options-not-permitted)
 			     stream
-			     (language cleavir-i18n:english))
+			     (language acclimation:english))
   (format stream
 	  "A slot can not have multiple :allocation options.~@
            ~s was found."
 	  (type-error-datum c)))
 
-(defmethod cleavir-i18n:report-condition ((c multiple-type-options-not-permitted)
+(defmethod acclimation:report-condition ((c multiple-type-options-not-permitted)
 			     stream
-			     (language cleavir-i18n:english))
+			     (language acclimation:english))
   (format stream
 	  "A slot can not have multiple :type options.~@
            ~s was found."
 	  (type-error-datum c)))
 
-(defmethod cleavir-i18n:report-condition ((c slot-documentation-option-must-be-string)
+(defmethod acclimation:report-condition ((c slot-documentation-option-must-be-string)
 			     stream
-			     (language cleavir-i18n:english))
+			     (language acclimation:english))
   (format stream
 	  "The :documentation option of a slot must have a string argument, but~@
            ~s was found."
 	  (type-error-datum c)))
 
-(defmethod cleavir-i18n:report-condition ((c class-option-must-be-non-empty-list)
+(defmethod acclimation:report-condition ((c class-option-must-be-non-empty-list)
 			     stream
-			     (langauge cleavir-i18n:english))
+			     (langauge acclimation:english))
   (format stream
 	  "A class option must be a a non-empty list, but~@
            ~s was found."
 	  (type-error-datum c)))
 
-(defmethod cleavir-i18n:report-condition ((c class-option-name-must-be-symbol)
+(defmethod acclimation:report-condition ((c class-option-name-must-be-symbol)
 			     stream
-			     (langauge cleavir-i18n:english))
+			     (langauge acclimation:english))
   (format stream
 	  "A class option name must be a symbol, but~@
            ~s was found."
 	  (type-error-datum c)))
 
-(defmethod cleavir-i18n:report-condition ((c malformed-documentation-option)
+(defmethod acclimation:report-condition ((c malformed-documentation-option)
 			     stream
-			     (langauge cleavir-i18n:english))
+			     (langauge acclimation:english))
   (format stream
 	  "A documentation option must have the form~@
            (:documentation <name>), but~@
            ~s was found."
 	  (type-error-datum c)))
 
-(defmethod cleavir-i18n:report-condition ((c malformed-metaclass-option)
+(defmethod acclimation:report-condition ((c malformed-metaclass-option)
 			     stream
-			     (langauge cleavir-i18n:english))
+			     (langauge acclimation:english))
   (format stream
 	  "A documentation option must have the form~@
            (:documentation <name>), but~@
            ~s was found."
 	  (type-error-datum c)))
 
-(defmethod cleavir-i18n:report-condition ((c malformed-default-initargs-option)
+(defmethod acclimation:report-condition ((c malformed-default-initargs-option)
 			     stream
-			     (langauge cleavir-i18n:english))
+			     (langauge acclimation:english))
   (format stream
 	  "The DEFAULT-INITARG option takes the form~@
            (:default-initargs <name> <value> <name> <value>...), but~@
            ~s was found."
 	  (type-error-datum c)))
 
-(defmethod cleavir-i18n:report-condition ((c default-initargs-option-once)
+(defmethod acclimation:report-condition ((c default-initargs-option-once)
 			     stream
-			     (langauge cleavir-i18n:english))
+			     (langauge acclimation:english))
   (format stream
 	  "The default-initargs option can appear only once in the~@
            list of class options, but a second such option:~@
            ~s was found."
 	  (type-error-datum c)))
 
-(defmethod cleavir-i18n:report-condition ((c documentation-option-once)
+(defmethod acclimation:report-condition ((c documentation-option-once)
 			     stream
-			     (langauge cleavir-i18n:english))
+			     (langauge acclimation:english))
   (format stream
 	  "The documentation option can appear only once in the~@
            list of class options, but a second such option:~@
            ~s was found."
 	  (type-error-datum c)))
 
-(defmethod cleavir-i18n:report-condition ((c metaclass-option-once)
+(defmethod acclimation:report-condition ((c metaclass-option-once)
 			     stream
-			     (langauge cleavir-i18n:english))
+			     (langauge acclimation:english))
   (format stream
 	  "The metaclass option can appear only once in the~@
            list of class options, but a second such option:~@
            ~s was found."
 	  (type-error-datum c)))
 
-(defmethod cleavir-i18n:report-condition ((c unknown-class-option)
+(defmethod acclimation:report-condition ((c unknown-class-option)
 			     stream
-			     (langauge cleavir-i18n:english))
+			     (langauge acclimation:english))
   (format stream
 	  "A class option is either ~@
            :default-initargs, :documentation, or :metaclass, but~@
@@ -435,8 +435,8 @@
 ;;;
 ;;; Argument mismatch conditions.
 
-(defmethod cleavir-i18n:report-condition
-    ((c too-few-arguments) stream (language cleavir-i18n:english))
+(defmethod acclimation:report-condition
+    ((c too-few-arguments) stream (language acclimation:english))
   (format stream
 	  "Too few arguments were given.  The lambda list is:~@
            ~s~@
@@ -445,8 +445,8 @@
 	  (lambda-list c)
 	  (arguments c)))
 
-(defmethod cleavir-i18n:report-condition
-    ((c too-many-arguments) stream (language cleavir-i18n:english))
+(defmethod acclimation:report-condition
+    ((c too-many-arguments) stream (language acclimation:english))
   (format stream
 	  "Too many arguments were given.  The lambda list is:~@
            ~s~@
@@ -455,8 +455,8 @@
 	  (lambda-list c)
 	  (arguments c)))
 
-(defmethod cleavir-i18n:report-condition
-    ((c unrecognized-keyword-argument) stream (language cleavir-i18n:english))
+(defmethod acclimation:report-condition
+    ((c unrecognized-keyword-argument) stream (language acclimation:english))
   (format stream
 	  "The keyword argument:~@
            ~s~@

--- a/Code/Conditions/Additional/conditions.lisp
+++ b/Code/Conditions/Additional/conditions.lisp
@@ -12,13 +12,13 @@
 ;;;; The software is provided "as-is" with no warranty.  The user of
 ;;;; this software assumes any responsibility of the consequences. 
 
-(define-condition sicl-warning (cleavir-i18n:condition warning) ())
-(define-condition sicl-style-warning (cleavir-i18n:condition style-warning) ())
-(define-condition sicl-error (cleavir-i18n:condition  error) ())
-(define-condition sicl-type-error (cleavir-i18n:condition type-error) ())
-(define-condition sicl-cell-error (cleavir-i18n:condition cell-error) ())
-(define-condition sicl-unbound-variable (cleavir-i18n:condition unbound-variable) ())
-(define-condition sicl-undefined-function (cleavir-i18n:condition undefined-function) ())
+(define-condition sicl-warning (acclimation:condition warning) ())
+(define-condition sicl-style-warning (acclimation:condition style-warning) ())
+(define-condition sicl-error (acclimation:condition  error) ())
+(define-condition sicl-type-error (acclimation:condition type-error) ())
+(define-condition sicl-cell-error (acclimation:condition cell-error) ())
+(define-condition sicl-unbound-variable (acclimation:condition unbound-variable) ())
+(define-condition sicl-undefined-function (acclimation:condition undefined-function) ())
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;
@@ -86,16 +86,16 @@
 ;;;
 ;;; Compile time conditions. 
 
-(define-condition sicl-program-error (cleavir-i18n:condition program-error)
+(define-condition sicl-program-error (acclimation:condition program-error)
   ())
 
 (define-condition sicl-syntax-error (sicl-program-error)
   ((%code :initarg :code :reader code)))
 
-(define-condition sicl-program-warning (cleavir-i18n:condition warning)
+(define-condition sicl-program-warning (acclimation:condition warning)
   ((%code :initarg :code :reader code)))
 
-(define-condition sicl-program-style-warning (cleavir-i18n:condition style-warning)
+(define-condition sicl-program-style-warning (acclimation:condition style-warning)
   ((%code :initarg :code :reader code)))
 
 

--- a/Code/Cons-high/condition-reporters-en.lisp
+++ b/Code/Cons-high/condition-reporters-en.lisp
@@ -20,18 +20,18 @@
   (let ((real-name (if (symbolp name) name (cadr name))))
     (package-name (symbol-package real-name))))
 
-(defmethod cleavir-i18n:report-condition ((c both-test-and-test-not-given)
+(defmethod acclimation:report-condition ((c both-test-and-test-not-given)
 					  stream
-					  (language cleavir-i18n:english))
+					  (language acclimation:english))
   (format stream
 	  "In ~a (in the ~a package):~@
            Both keyword arguments :test and :test-not were given."
 	  (name c)
 	  (name-package (name c))))
 
-(defmethod cleavir-i18n:report-condition ((c must-be-nonnegative-integer)
+(defmethod acclimation:report-condition ((c must-be-nonnegative-integer)
 					  stream
-					  (language cleavir-i18n:english))
+					  (language acclimation:english))
   (format stream
 	  "In ~a (in the ~a package):~@
            A nonnegative integer was required,~@
@@ -41,9 +41,9 @@
 	  (name-package (name c))
 	  (type-error-datum c)))
 
-(defmethod cleavir-i18n:report-condition ((c must-be-cons)
+(defmethod acclimation:report-condition ((c must-be-cons)
 					  stream
-					  (language cleavir-i18n:english))
+					  (language acclimation:english))
   (format stream
 	  "In ~a (in the ~a package):~@
            A cons cell was required,~@
@@ -53,9 +53,9 @@
 	  (name-package (name c))
 	  (type-error-datum c)))
 
-(defmethod cleavir-i18n:report-condition ((c must-be-list)
+(defmethod acclimation:report-condition ((c must-be-list)
 					  stream
-					  (language cleavir-i18n:english))
+					  (language acclimation:english))
   (format stream
 	  "In ~a (in the ~a package):~@
            A list (a cons or nil) was required,~@
@@ -65,9 +65,9 @@
 	  (name-package (name c))
 	  (type-error-datum c)))
 
-(defmethod cleavir-i18n:report-condition ((c must-be-proper-list)
+(defmethod acclimation:report-condition ((c must-be-proper-list)
 					  stream
-					  (language cleavir-i18n:english))
+					  (language acclimation:english))
   (format stream
 	  "In ~a (in the ~a package):~@
            A proper list was required,~@
@@ -77,9 +77,9 @@
 	  (name-package (name c))
 	  (type-error-datum c)))
 
-(defmethod cleavir-i18n:report-condition ((c must-be-proper-or-circular-list)
+(defmethod acclimation:report-condition ((c must-be-proper-or-circular-list)
 					  stream
-					  (language cleavir-i18n:english))
+					  (language acclimation:english))
   (format stream
 	  "In ~a (in the ~a package):~@
            A proper or circular list was required,~@
@@ -89,9 +89,9 @@
 	  (name-package (name c))
 	  (type-error-datum c)))
 
-(defmethod cleavir-i18n:report-condition ((c must-be-proper-or-dotted-list)
+(defmethod acclimation:report-condition ((c must-be-proper-or-dotted-list)
 					  stream
-					  (language cleavir-i18n:english))
+					  (language acclimation:english))
   (format stream
 	  "In ~a (in the ~a package):~@
            A proper or dotted list was required,~@
@@ -101,9 +101,9 @@
 	  (name-package (name c))
 	  (type-error-datum c)))
 
-(defmethod cleavir-i18n:report-condition ((c must-be-property-list)
+(defmethod acclimation:report-condition ((c must-be-property-list)
 					  stream
-					  (language cleavir-i18n:english))
+					  (language acclimation:english))
   (format stream
 	  "In ~a (in the ~a package):~@
            A property list was required,~@
@@ -113,9 +113,9 @@
 	  (name-package (name c))
 	  (type-error-datum c)))
 
-(defmethod cleavir-i18n:report-condition ((c must-be-association-list)
+(defmethod acclimation:report-condition ((c must-be-association-list)
 					  stream
-					  (language cleavir-i18n:english))
+					  (language acclimation:english))
   (format stream
 	  "In ~a (in the ~a package):~@
            A association list was required,~@
@@ -125,9 +125,9 @@
 	  (name-package (name c))
 	  (type-error-datum c)))
 
-(defmethod cleavir-i18n:report-condition ((c at-least-one-list-required)
+(defmethod acclimation:report-condition ((c at-least-one-list-required)
 					  stream
-					  (language cleavir-i18n:english))
+					  (language acclimation:english))
   (format stream
 	  "In ~a (in the ~a package):~@
            At least one list argument is required,~@
@@ -135,9 +135,9 @@
 	  (name c)
 	  (name-package (name c))))
 	  
-(defmethod cleavir-i18n:report-condition ((c at-least-one-argument-required)
+(defmethod acclimation:report-condition ((c at-least-one-argument-required)
 					  stream
-					  (language cleavir-i18n:english))
+					  (language acclimation:english))
   (format stream
 	  "In ~a (in the ~a package):~@
            At least one argument is required,~@
@@ -145,9 +145,9 @@
 	  (name c)
 	  (name-package (name c))))
 
-(defmethod cleavir-i18n:report-condition ((c lists-must-have-the-same-length)
+(defmethod acclimation:report-condition ((c lists-must-have-the-same-length)
 					  stream
-					  (language cleavir-i18n:english))
+					  (language acclimation:english))
   (format stream
 	  "In ~a (in the ~a package):~@
            The two lists passed as arguments must~@
@@ -161,9 +161,9 @@
 	  (list1 c)
 	  (list2 c)))
 
-(defmethod cleavir-i18n:report-condition ((c setf-c*r-must-be-cons)
+(defmethod acclimation:report-condition ((c setf-c*r-must-be-cons)
 					  stream
-					  (language cleavir-i18n:english))
+					  (language acclimation:english))
   (format stream
 	  "In the SETF expander for ~a (in the ~a package),~@
            the ~aargument ~s~@
@@ -177,9 +177,9 @@
 	  (original-tree c)
 	  (type-error-datum c)))
 
-(defmethod cleavir-i18n:report-condition ((c setf-nth-must-be-cons)
+(defmethod acclimation:report-condition ((c setf-nth-must-be-cons)
 					  stream
-					  (language cleavir-i18n:english))
+					  (language acclimation:english))
   (format stream
 	  "In the SETF expander for ~a (in the ~a package),~@
            the ~:R CDR of the argument ~s~@
@@ -191,19 +191,19 @@
 	  (original-tree c)
 	  (type-error-datum c)))
 
-(defmethod cleavir-i18n:report-condition ((c warn-both-test-and-test-not-given)
+(defmethod acclimation:report-condition ((c warn-both-test-and-test-not-given)
 					  stream
-					  (language cleavir-i18n:english))
+					  (language acclimation:english))
   (format stream
 	  "In ~a (in the ~a package),~@
            both keyword arguments :test and :test-not were given."
 	  (name c)
 	  (name-package (name c))))
 
-(defmethod cleavir-i18n:report-condition
+(defmethod acclimation:report-condition
     ((c expected-list-with-at-least-n-elements)
      stream
-     (language cleavir-i18n:english))
+     (language acclimation:english))
   (format stream
 	  "Expected a list with at least ~d elements,~@
            but the following was given instead:~@

--- a/Code/Cons-high/conditions.lisp
+++ b/Code/Cons-high/conditions.lisp
@@ -48,35 +48,35 @@
 ;;; This condition is used by functions an macros that require 
 ;;; some argument to be a nonnegative integer. 
 (define-condition must-be-nonnegative-integer
-    (type-error name-mixin cleavir-i18n:condition)
+    (type-error name-mixin acclimation:condition)
   ()
   (:default-initargs :expected-type '(integer 0)))
 
 ;;; This condition is used by functions and macros that require
 ;;; some argument to be a cons cell.
 (define-condition must-be-cons
-    (type-error name-mixin cleavir-i18n:condition)
+    (type-error name-mixin acclimation:condition)
   ()
   (:default-initargs :expected-type 'cons))
 
 ;;; This condition is used by functions and macros that require
 ;;; some argument to be a list (a cons or nil).
 (define-condition must-be-list
-    (type-error name-mixin cleavir-i18n:condition)
+    (type-error name-mixin acclimation:condition)
   ()
   (:default-initargs :expected-type 'list))
 
 ;;; This condition is used by functions and macros that require
 ;;; some list to be a proper list.  
 (define-condition must-be-proper-list
-    (type-error name-mixin cleavir-i18n:condition)
+    (type-error name-mixin acclimation:condition)
   ()
   (:default-initargs :expected-type 'list))
 
 ;;; This condition is used by functions and macros that require
 ;;; some list to be either a proper list or a circular list.
 (define-condition must-be-proper-or-circular-list
-    (type-error name-mixin cleavir-i18n:condition)
+    (type-error name-mixin acclimation:condition)
   ()
   (:default-initargs :expected-type 'list))
 
@@ -84,47 +84,47 @@
 ;;; list to be either a proper list or a dotted list (but not a
 ;;; circular list). 
 (define-condition must-be-proper-or-dotted-list
-    (type-error name-mixin cleavir-i18n:condition)
+    (type-error name-mixin acclimation:condition)
   ()
   (:default-initargs :expected-type 'list))
 
 ;;; This condition is used by functions and macros that require
 ;;; some argument to be a propterty list.
 (define-condition must-be-property-list
-    (type-error name-mixin cleavir-i18n:condition)
+    (type-error name-mixin acclimation:condition)
   ()
   (:default-initargs :expected-type 'list))
 
 ;;; This condition is used by functions and macros that require
 ;;; some argument to be a association list.
 (define-condition must-be-association-list
-    (type-error name-mixin cleavir-i18n:condition)
+    (type-error name-mixin acclimation:condition)
   ()
   (:default-initargs :expected-type 'list))
 
 ;;; This condition is used by functions that take :test and :test-not
 ;;; keyword arguments, and is signaled when both of those are given.
 (define-condition both-test-and-test-not-given
-    (error name-mixin cleavir-i18n:condition)
+    (error name-mixin acclimation:condition)
   ())
 
 ;;; This condition is used by the map* family functions when no lists
 ;;; were given, since those functions require at least one list
 ;;; argument.
 (define-condition at-least-one-list-required
-    (error name-mixin cleavir-i18n:condition)
+    (error name-mixin acclimation:condition)
   ())
 
 ;;; This condition is used by the list* function when no arguments
 ;;; were given, since that function requires at least one argument.
 (define-condition at-least-one-argument-required
-    (error name-mixin cleavir-i18n:condition)
+    (error name-mixin acclimation:condition)
   ())
 
 ;;; This condition is used by the pairlis function when 
 ;;; the two lists are not of the same length.
 (define-condition lists-must-have-the-same-length
-    (error name-mixin cleavir-i18n:condition)
+    (error name-mixin acclimation:condition)
   ((%list1 :initarg :list1 :reader list1)
    (%list2 :initarg :list2 :reader list2)))
 
@@ -147,6 +147,6 @@
   ())
 
 (define-condition expected-list-with-at-least-n-elements
-    (error cleavir-i18n:condition)
+    (error acclimation:condition)
   ((%found :initarg :found :reader found)
    (%at-least :initarg :at-least :reader at-least)))

--- a/Code/Data-and-control-flow/condition-reporters-english.lisp
+++ b/Code/Data-and-control-flow/condition-reporters-english.lisp
@@ -1,39 +1,39 @@
 (cl:in-package #:sicl-data-and-control-flow)
 
-(defmethod cleavir-i18n:report-condition
+(defmethod acclimation:report-condition
     ((condition odd-number-of-arguments-to-setf)
      stream
-     (langauge cleavir-i18n:english))
+     (langauge acclimation:english))
   (format stream
 	  "An odd number of arguments was given to SETF~@
            in the following form:~@
            ~s"
           (form condition)))
 
-(defmethod cleavir-i18n:report-condition
+(defmethod acclimation:report-condition
     ((condition odd-number-of-arguments-to-psetf)
      stream
-     (langauge cleavir-i18n:english))
+     (langauge acclimation:english))
   (format stream
 	  "An odd number of arguments was given to PSETF~@
            in the following form:~@
            ~s"
           (form condition)))
 
-(defmethod cleavir-i18n:report-condition
+(defmethod acclimation:report-condition
     ((condition odd-number-of-arguments-to-psetq)
      stream
-     (langauge cleavir-i18n:english))
+     (langauge acclimation:english))
   (format stream
 	  "An odd number of arguments was given to PSETQ~@
            in the following form:~@
            ~s"
           (form condition)))
 
-(defmethod cleavir-i18n:report-condition
+(defmethod acclimation:report-condition
     ((condition too-few-arguments-to-shiftf)
      stream
-     (langauge cleavir-i18n:english))
+     (langauge acclimation:english))
   (format stream
 	  "Too few arguments were given to SHIFTF~@
            in the following form:~@

--- a/Code/Data-and-control-flow/conditions.lisp
+++ b/Code/Data-and-control-flow/conditions.lisp
@@ -1,17 +1,17 @@
 (cl:in-package #:sicl-data-and-control-flow)
 
 (define-condition odd-number-of-arguments-to-setf
-    (program-error cleavir-i18n:condition)
+    (program-error acclimation:condition)
   ((%form :initarg :form :reader form)))
 
 (define-condition odd-number-of-arguments-to-psetf
-    (program-error cleavir-i18n:condition)
+    (program-error acclimation:condition)
   ((%form :initarg :form :reader form)))
 
 (define-condition odd-number-of-arguments-to-psetq
-    (program-error cleavir-i18n:condition)
+    (program-error acclimation:condition)
   ((%form :initarg :form :reader form)))
 
 (define-condition too-few-arguments-to-shiftf
-    (program-error cleavir-i18n:condition)
+    (program-error acclimation:condition)
   ((%form :initarg :form :reader form)))

--- a/Code/Environment/condition-reporters-english.lisp
+++ b/Code/Environment/condition-reporters-english.lisp
@@ -1,23 +1,23 @@
 (cl:in-package #:sicl-standard-environment-functions)
 
-(defmethod cleavir-i18n:report-condition
-    ((condition no-such-class) stream (langauge cleavir-i18n:english))
+(defmethod acclimation:report-condition
+    ((condition no-such-class) stream (langauge acclimation:english))
   (format stream "There is no class named ~s" (name condition)))
 
-(defmethod cleavir-i18n:report-condition
+(defmethod acclimation:report-condition
     ((condition variables-must-be-proper-list)
      stream
-     (langauge cleavir-i18n:english))
+     (langauge acclimation:english))
   (format stream
 	  "The variables to be bound by MULTIPLE-VALUE-BIND must~@
            be a proper list, but the following was found instead:~@
            ~s"
          (variables condition)))
 
-(defmethod cleavir-i18n:report-condition
+(defmethod acclimation:report-condition
     ((condition variable-must-be-symbol)
      stream
-     (langauge cleavir-i18n:english))
+     (langauge acclimation:english))
   (format stream
 	  "A variable to be bound by MULTIPLE-VALUE-BIND must~@
            be a symbol, but the following was found instead:~@

--- a/Code/Evaluation-and-compilation/condition-reporters-english.lisp
+++ b/Code/Evaluation-and-compilation/condition-reporters-english.lisp
@@ -1,9 +1,9 @@
 (cl:in-package #:sicl-evaluation-and-compilation)
 
-(defmethod cleavir-i18n:report-condition
+(defmethod acclimation:report-condition
     ((condition environment-must-be-omitted-or-nil)
      stream
-     (language cleavir-i18n:english))
+     (language acclimation:english))
   (format stream
 	  "The optional environment argument must either be~@
            omitted or NIL, but the following was found instead:~%~s"

--- a/Code/Evaluation-and-compilation/conditions.lisp
+++ b/Code/Evaluation-and-compilation/conditions.lisp
@@ -1,5 +1,5 @@
 (cl:in-package #:sicl-evaluation-and-compilation)
 
 (define-condition environment-must-be-omitted-or-nil
-    (error cleavir-i18n:condition)
+    (error acclimation:condition)
   ((%environment :initarg :environment :reader environment)))

--- a/Code/Format/condition-reporters-en.lisp
+++ b/Code/Format/condition-reporters-en.lisp
@@ -19,29 +19,29 @@
 	    start
 	    end)))
 
-(defmethod cleavir-i18n:report-condition
+(defmethod acclimation:report-condition
     ((condition end-of-control-string-error)
      stream
-     (language cleavir-i18n:english))
+     (language acclimation:english))
   (report-control-string-and-directive-start-position condition stream)
   (format stream
 	  "~a, but reached the end of the control string"
 	  (why condition)))
 
-(defmethod cleavir-i18n:report-condition
+(defmethod acclimation:report-condition
     ((condition expected-integer-error)
      stream
-     (language cleavir-i18n:english))
+     (language acclimation:english))
   (report-control-string-and-directive-start-position condition stream)
   (format stream
 	  "expected an integer at index ~a,~% but found the character `~a' instead"
 	  (index condition)
 	  (char (control-string condition) (index condition))))
 
-(defmethod cleavir-i18n:report-condition
+(defmethod acclimation:report-condition
     ((condition expected-parameter-start)
      stream
-     (language cleavir-i18n:english))
+     (language acclimation:english))
   (report-control-string-and-directive-start-position condition stream)
   (format stream
 	  "expected one of ', +, -, or a decimal digit at index ~a,~%~
@@ -49,223 +49,223 @@
 	  (index condition)
 	  (char (control-string condition) (index condition))))
 
-(defmethod cleavir-i18n:report-condition
+(defmethod acclimation:report-condition
     ((condition two-identical-modifiers)
      stream
-     (language cleavir-i18n:english))
+     (language acclimation:english))
   (report-control-string-and-directive-start-position condition stream)
   (format stream
 	  "found two identical modifiers `~a' at index ~a"
 	  (char (control-string condition) (index condition))
 	  (index condition)))
 
-(defmethod cleavir-i18n:report-condition
+(defmethod acclimation:report-condition
     ((condition more-than-two-modifiers)
      stream
-     (language cleavir-i18n:english))
+     (language acclimation:english))
   (report-control-string-and-directive-start-position condition stream)
   (format stream
 	  "found a sequence of more than two modifiers at index ~a"
 	  (index condition)))
 
-(defmethod cleavir-i18n:report-condition
+(defmethod acclimation:report-condition
     ((condition unknown-format-directive)
      stream
-     (language cleavir-i18n:english))
+     (language acclimation:english))
   (report-control-string-and-directive-start-position condition stream)
   (format stream
 	  "unknown format directive `~a' at index ~a"
 	  (char (control-string condition) (index condition))
 	  (index condition)))
 
-(defmethod cleavir-i18n:report-condition
+(defmethod acclimation:report-condition
     ((condition unknown-directive-character)
      stream
-     (language cleavir-i18n:english))
+     (language acclimation:english))
   (report-control-string-and-directive-position condition stream)
   (format stream
 	  "unknown directive character: ~c~%"
 	  (directive-character (directive condition))))
 
 ;;; FIXME, report the index
-(defmethod cleavir-i18n:report-condition
+(defmethod acclimation:report-condition
     ((condition directive-takes-no-modifiers)
      stream
-     (language cleavir-i18n:english))
+     (language acclimation:english))
   (report-control-string-and-directive-position condition stream)
   (format stream
 	  "found a modifier at index,~%but this ~
            directive takes no modifiers"))
 
 ;;; FIXME, report the index
-(defmethod cleavir-i18n:report-condition
+(defmethod acclimation:report-condition
     ((condition directive-takes-only-colon)
      stream
-     (language cleavir-i18n:english))
+     (language acclimation:english))
   (report-control-string-and-directive-position condition stream)
   (format stream
 	  "found an at-sign at index,~%but this directive ~
            takes only the colon modifier"))
 
 ;;; FIXME, report the index
-(defmethod cleavir-i18n:report-condition
+(defmethod acclimation:report-condition
     ((condition directive-takes-only-at-sign)
      stream
-     (language cleavir-i18n:english))
+     (language acclimation:english))
   (report-control-string-and-directive-position condition stream)
   (format stream
 	  "found a colon at index,~%but this directive ~
            takes only the at-sign modifier"))
 
 ;;; FIXME, report the index
-(defmethod cleavir-i18n:report-condition
+(defmethod acclimation:report-condition
     ((condition directive-takes-at-most-one-modifier)
      stream
-     (language cleavir-i18n:english))
+     (language acclimation:english))
   (report-control-string-and-directive-position condition stream)
   (format stream
 	  "found both modifiers,~%but this directive ~
            takes at most one modifier"))
 
-(defmethod cleavir-i18n:report-condition
+(defmethod acclimation:report-condition
     ((condition too-many-parameters)
      stream
-     (language cleavir-i18n:english))
+     (language acclimation:english))
   (report-control-string-and-directive-position condition stream)
   (format stream
 	  "the directive takes at most ~a parameters,~%but ~a found"
 	  (at-most-how-many condition)
 	  (how-many-found condition)))
 
-(defmethod cleavir-i18n:report-condition
+(defmethod acclimation:report-condition
     ((condition parameter-type-error)
      stream
-     (language cleavir-i18n:english))
+     (language acclimation:english))
   (format stream
 	  "~a was required as parameter, but ~a was found"
 	  (type-name (type-error-expected-type condition))
 	  (type-error-datum condition)))
 
-(defmethod cleavir-i18n:report-condition
+(defmethod acclimation:report-condition
     ((condition no-more-arguments)
      stream
-     (language cleavir-i18n:english))
+     (language acclimation:english))
   (format stream "an attempt was made to access more arguments than available"))
 
-(defmethod cleavir-i18n:report-condition
+(defmethod acclimation:report-condition
     ((condition argument-type-error)
      stream
-     (language cleavir-i18n:english))
+     (language acclimation:english))
   (format stream
 	  "~a was required as argument, but ~a was found"
 	  (type-name (type-error-expected-type condition))
 	  (type-error-datum condition)))
 
-(defmethod cleavir-i18n:report-condition
+(defmethod acclimation:report-condition
     ((condition too-many-package-markers)
      stream
-     (language cleavir-i18n:english))
+     (language acclimation:english))
   (report-control-string-and-directive-position condition stream)
   (format stream "the function name contains too many package markers"))
 
-(defmethod cleavir-i18n:report-condition
+(defmethod acclimation:report-condition
     ((condition no-such-package)
      stream
-     (language cleavir-i18n:english))
+     (language acclimation:english))
   (report-control-string-and-directive-position condition stream)
   (format stream "the named package does not exist"))
 
-(defmethod cleavir-i18n:report-condition
+(defmethod acclimation:report-condition
     ((condition no-such-symbol)
      stream
-     (language cleavir-i18n:english))
+     (language acclimation:english))
   (report-control-string-and-directive-position condition stream)
   (format stream "a symbol with that name does not exist"))
 
-(defmethod cleavir-i18n:report-condition
+(defmethod acclimation:report-condition
     ((condition symbol-not-external)
      stream
-     (language cleavir-i18n:english))
+     (language acclimation:english))
   (report-control-string-and-directive-position condition stream)
   (format stream "the symbol is not external in the package"))
 
-(defmethod cleavir-i18n:report-condition
+(defmethod acclimation:report-condition
     ((condition go-to-out-of-bounds)
      stream
-     (language cleavir-i18n:english))
+     (language acclimation:english))
   (format stream "an attempt was made to go to argument number ~d ~
                   instead of one between 0 and ~d"
 	  (what-argument condition)
 	  (max-arguments condition)))
 
-(defmethod cleavir-i18n:report-condition
+(defmethod acclimation:report-condition
     ((condition modifier-and-parameter)
      stream
-     (language cleavir-i18n:english))
+     (language acclimation:english))
   (format stream "a parameter can be used only of there are no modifiers"))
 
-(defmethod cleavir-i18n:report-condition
+(defmethod acclimation:report-condition
     ((condition illegal-clause-separators)
      stream
-     (language cleavir-i18n:english))
+     (language acclimation:english))
   (format stream "at most the last clause separator can have ~
                   a `:' modifier"))
 
-(defmethod cleavir-i18n:report-condition
+(defmethod acclimation:report-condition
     ((condition clause-separator-with-colon-modifier-not-allowed)
      stream
-     (language cleavir-i18n:english))
+     (language acclimation:english))
   (format stream "a default clause is incompatible with modifiers"))
 
-(defmethod cleavir-i18n:report-condition
+(defmethod acclimation:report-condition
     ((condition at-least-one-item-required)
      stream
-     (language cleavir-i18n:english))
+     (language acclimation:english))
   (format stream "there must be at least one clause in a ~
                   conditional directive"))
 
-(defmethod cleavir-i18n:report-condition
+(defmethod acclimation:report-condition
     ((condition colon-modifier-requires-two-clauses)
      stream
-     (language cleavir-i18n:english))
+     (language acclimation:english))
   (format stream "a colon modifier requires two clauses"))
 
-(defmethod cleavir-i18n:report-condition
+(defmethod acclimation:report-condition
     ((condition at-sign-modifier-requires-one-clause)
      stream
-     (language cleavir-i18n:english))
+     (language acclimation:english))
   (format stream "an at-sign modifier requires a single clause"))
 
-(defmethod cleavir-i18n:report-condition
+(defmethod acclimation:report-condition
     ((condition parameter-omitted)
      stream
-     (language cleavir-i18n:english))
+     (language acclimation:english))
   (format stream
 	  "parameter number ~d was given, but parameter ~d ~
            was omitted, which is not allowed"
 	  (parameter1 condition)
 	  (parameter2 condition)))
 
-(defmethod cleavir-i18n:report-condition
+(defmethod acclimation:report-condition
     ((condition unmatched-directive)
      stream
-     (language cleavir-i18n:english))
+     (language acclimation:english))
   (report-control-string-and-directive-position condition stream)
   (format stream
 	  "there is no matching directive"))
 
-(defmethod cleavir-i18n:report-condition
+(defmethod acclimation:report-condition
     ((condition nesting-violation)
      stream
-     (language cleavir-i18n:english))
+     (language acclimation:english))
   (report-control-string-and-directive-position condition stream)
   (format stream
 	  "the directive is not nested properly"))
 
-(defmethod cleavir-i18n:report-condition
+(defmethod acclimation:report-condition
     ((condition invalid-destination)
      stream
-     (language cleavir-i18n:english))
+     (language acclimation:english))
   (format stream
 	  "the object ~s is not a valid destination for a format operation"
 	  (destination condition)))

--- a/Code/Format/conditions.lisp
+++ b/Code/Format/conditions.lisp
@@ -2,7 +2,7 @@
 
 ;;; The base class of all format errors.
 
-(define-condition format-error (error cleavir-i18n:condition) ())
+(define-condition format-error (error acclimation:condition) ())
 
 ;;; This is the base class for all parse errors, i.e. error found
 ;;; before we were able to construct a directive object at all.  All

--- a/Code/Iteration/condition-reporters-en.lisp
+++ b/Code/Iteration/condition-reporters-en.lisp
@@ -7,9 +7,9 @@
 ;;; I used to think that we should not use FORMAT for these condition
 ;;; reporters.  I now think it is OK.  RS -- 2014-09-15.
 
-(defmethod cleavir-i18n:report-condition ((c malformed-binding-var)
+(defmethod acclimation:report-condition ((c malformed-binding-var)
 					  stream
-					  (language cleavir-i18n:english))
+					  (language acclimation:english))
   (format stream
 	  "In ~a (in the ~a package):~@
            The binding variable must be a symbol,~@
@@ -19,9 +19,9 @@
 	  (name-package (name c))
           (type-error-datum c)))
 
-(defmethod cleavir-i18n:report-condition ((c malformed-list-form)
+(defmethod acclimation:report-condition ((c malformed-list-form)
 					  stream
-					  (language cleavir-i18n:english))
+					  (language acclimation:english))
   (format stream
 	  "In ~a (in the ~a package):~@
            The list form must be a list,~@
@@ -31,9 +31,9 @@
 	  (name-package (name c))
 	  (type-error-datum c)))
 
-(defmethod cleavir-i18n:report-condition ((c malformed-count-form)
+(defmethod acclimation:report-condition ((c malformed-count-form)
 					  stream
-					  (language cleavir-i18n:english))
+					  (language acclimation:english))
   (format stream
 	  "In ~a (in the ~a package):~@
            The count form must be a non-negative integer,~@
@@ -43,9 +43,9 @@
 	  (name-package (name c))
 	  (type-error-datum c)))
 
-(defmethod cleavir-i18n:report-condition ((c malformed-body)
+(defmethod acclimation:report-condition ((c malformed-body)
 					  stream
-					  (language cleavir-i18n:english))
+					  (language acclimation:english))
   (format stream
 	  "In ~a (in the ~a package):~@
            The body must be a proper list,~@
@@ -55,9 +55,9 @@
 	  (name-package (name c))
 	  (type-error-datum c)))
 
-(defmethod cleavir-i18n:report-condition ((c malformed-variable-clauses)
+(defmethod acclimation:report-condition ((c malformed-variable-clauses)
 					  stream
-					  (language cleavir-i18n:english))
+					  (language acclimation:english))
   (format stream
 	  "In ~a (in the ~a package):~@
            Expected a proper list of variable clauses~@
@@ -67,9 +67,9 @@
 	  (name-package (name c))
 	  (type-error-datum c)))
 
-(defmethod cleavir-i18n:report-condition ((c malformed-variable-clause)
+(defmethod acclimation:report-condition ((c malformed-variable-clause)
 					  stream
-					  (language cleavir-i18n:english))
+					  (language acclimation:english))
   (format stream
 	  "In ~a (in the ~a package):~@
            Expected a variable clause of the form~@
@@ -80,9 +80,9 @@
 	  (name-package (name c))
 	  (found c)))
 
-(defmethod cleavir-i18n:report-condition ((c malformed-end-test)
+(defmethod acclimation:report-condition ((c malformed-end-test)
 					  stream
-					  (language cleavir-i18n:english))
+					  (language acclimation:english))
   (format stream
 	  "In ~a (in the ~a package):~@
            Expected an end test clause of the form~@

--- a/Code/Iteration/conditions.lisp
+++ b/Code/Iteration/conditions.lisp
@@ -11,40 +11,40 @@
   ((%name :initarg :name :reader name)))
 
 (define-condition malformed-binding-var
-    (type-error name-mixin cleavir-i18n:condition)
+    (type-error name-mixin acclimation:condition)
   ()
   (:default-initargs :expected-type 'symbol))
 
 ;;; This condition is used by functions and macros that require
 ;;; some argument to be a list (a cons or nil).
 (define-condition malformed-list-form
-    (type-error name-mixin cleavir-i18n:condition)
+    (type-error name-mixin acclimation:condition)
   ()
   (:default-initargs :expected-type 'list))
 
 ;;; This condition is used by functions and macros that require
 ;;; some argument to be a nonnegative integer.
 (define-condition malformed-count-form
-    (type-error name-mixin cleavir-i18n:condition)
+    (type-error name-mixin acclimation:condition)
   ()
   (:default-initargs :expected-type '(integer 0)))
 
 ;;; This condition is used by functions and macros that require
 ;;; some list to be a proper list.
 (define-condition malformed-body
-    (type-error name-mixin cleavir-i18n:condition)
+    (type-error name-mixin acclimation:condition)
   ()
   (:default-initargs :expected-type 'list))
 
 (define-condition malformed-variable-clauses
-    (type-error name-mixin cleavir-i18n:condition)
+    (type-error name-mixin acclimation:condition)
   ()
   (:default-initargs :expected-type 'list))
 
 (define-condition malformed-variable-clause
-    (program-error name-mixin cleavir-i18n:condition)
+    (program-error name-mixin acclimation:condition)
   ((%found :initarg :found :reader found)))
 
 (define-condition malformed-end-test
-    (program-error name-mixin cleavir-i18n:condition)
+    (program-error name-mixin acclimation:condition)
   ((%found :initarg :found :reader found)))

--- a/Code/Loop/compile-time-conditions.lisp
+++ b/Code/Loop/compile-time-conditions.lisp
@@ -19,12 +19,12 @@
 ;;; FIXME: Remove condition reporters from the DEFINE-CONDITION forms
 ;;; and put them in a separate (language-specific) file.  
 
-(define-condition loop-parse-error (parse-error cleavir-i18n:condition)
+(define-condition loop-parse-error (parse-error acclimation:condition)
   ())
 
 ;;; Root class for loop parse errors that report something that was
 ;;; found, but should not be there.
-(define-condition loop-parse-error-found (parse-error cleavir-i18n:condition)
+(define-condition loop-parse-error-found (parse-error acclimation:condition)
   ((%found :initarg :found :reader found)))
 
 (define-condition expected-var-spec-but-end (loop-parse-error)
@@ -116,7 +116,7 @@
 ;;;        conditions.
 
 ;;; The root of all syntax errors.
-(define-condition loop-syntax-error (program-error cleavir-i18n:condition)
+(define-condition loop-syntax-error (program-error acclimation:condition)
   ())
 
 ;;; This condition is signaled when a name-clause is found
@@ -138,5 +138,5 @@
   ((%bound-variable :initarg :bound-variable :reader bound-variable)))
 
 ;;; The root of all semantic errors.
-(define-condition loop-semantic-error (program-error cleavir-i18n:condition)
+(define-condition loop-semantic-error (program-error acclimation:condition)
   ())

--- a/Code/Loop/condition-reporters-english.lisp
+++ b/Code/Loop/condition-reporters-english.lisp
@@ -16,171 +16,171 @@
 ;;;
 ;;; Condition reporters for parse errors.
 
-(defmethod cleavir-i18n:report-condition
+(defmethod acclimation:report-condition
     ((condition expected-var-spec-but-end)
      stream
-     (language cleavir-i18n:english))
+     (language acclimation:english))
   (declare (ignorable condition))
   (format stream
 	  "Expected a variable specification, but reached~@
            the end of the loop body."))
 
-(defmethod cleavir-i18n:report-condition
+(defmethod acclimation:report-condition
     ((condition expected-var-spec-but-found)
      stream
-     (language cleavir-i18n:english))
+     (language acclimation:english))
   (format stream
 	  "Expected a variable specification but found~@
            the following instead:~@
            ~s"
 	  (found condition)))
 
-(defmethod cleavir-i18n:report-condition
+(defmethod acclimation:report-condition
     ((condition expected-simple-var-but-end)
      stream
-     (language cleavir-i18n:english))
+     (language acclimation:english))
   (declare (ignorable condition))
   (format stream
 	  "Expected a simple variable but reached~@
            the end of the loop body."))
 
-(defmethod cleavir-i18n:report-condition
+(defmethod acclimation:report-condition
     ((condition expected-simple-var-but-found)
      stream
-     (language cleavir-i18n:english))
+     (language acclimation:english))
   (format stream
 	  "Expected a simple variable but found~@
            the following instead:~@
            ~s"
 	  (found condition)))
 
-(defmethod cleavir-i18n:report-condition
+(defmethod acclimation:report-condition
     ((condition expected-type-spec-but-end)
      stream
-     (language cleavir-i18n:english))
+     (language acclimation:english))
   (declare (ignorable condition))
   (format stream
 	  "Expected a variable specification but reached~@
            the end of the loop body."))
 
-(defmethod cleavir-i18n:report-condition
+(defmethod acclimation:report-condition
     ((condition expected-type-spec-but-found)
      stream
-     (language cleavir-i18n:english))
+     (language acclimation:english))
   (format stream
 	  "Expected a type specification but found~@
            the following instead:~@
            ~s"
 	  (found condition)))
 
-(defmethod cleavir-i18n:report-condition
+(defmethod acclimation:report-condition
     ((condition expected-compound-form-but-end)
      stream
-     (language cleavir-i18n:english))
+     (language acclimation:english))
   (declare (ignorable condition))
      (format stream
 	     "Expected a compound form but reached ~
               the end of the loop body."))
 
-(defmethod cleavir-i18n:report-condition
+(defmethod acclimation:report-condition
     ((condition expected-compound-form-but-found)
      stream
-     (language cleavir-i18n:english))
+     (language acclimation:english))
   (format stream
 	  "Expected a compound form but found~@
            the following instead:~@
            ~s"
 	  (found condition)))
 
-(defmethod cleavir-i18n:report-condition
+(defmethod acclimation:report-condition
     ((condition expected-form-but-end)
      stream
-     (language cleavir-i18n:english))
+     (language acclimation:english))
   (declare (ignorable condition))
   (format stream
 	  "Expected a form but reached~@
            the end of the loop body."))
 
-(defmethod cleavir-i18n:report-condition
+(defmethod acclimation:report-condition
     ((condition expected-symbol-but-end)
      stream
-     (language cleavir-i18n:english))
+     (language acclimation:english))
   (declare (ignorable condition))
   (format stream
 	  "Expected a symbol but reached~@
            the end of the loop body."))
 
-(defmethod cleavir-i18n:report-condition
+(defmethod acclimation:report-condition
     ((condition expected-symbol-but-found)
      stream
-     (language cleavir-i18n:english))
+     (language acclimation:english))
   (format stream
 	  "Expected a symbol but found~@
            the following instead:~@
            ~s"
 	  (found condition)))
 
-(defmethod cleavir-i18n:report-condition
+(defmethod acclimation:report-condition
     ((condition expected-keyword-but-found)
      stream
-     (language cleavir-i18n:english))
+     (language acclimation:english))
   (format stream
 	  "Expected a loop keyword, but found~@
            the following instead:~@
            ~s"
 	  (found condition)))
 
-(defmethod cleavir-i18n:report-condition
+(defmethod acclimation:report-condition
     ((condition expected-for/as-subclause-but-end)
      stream
-     (language cleavir-i18n:english))
+     (language acclimation:english))
   (declare (ignorable condition))
   (format stream
 	  "Expected a loop keyword indicating a for/as~@
            subclause, but reached the end of the loop body."))
 
-(defmethod cleavir-i18n:report-condition
+(defmethod acclimation:report-condition
     ((condition expected-symbol-but-found)
      stream
-     (language cleavir-i18n:english))
+     (language acclimation:english))
   (format stream
 	  "Expected a loop keyword indicating a for/as~@
            subclause, but found the following instead:~@
            ~s"
 	  (found condition)))
 
-(defmethod cleavir-i18n:report-condition
+(defmethod acclimation:report-condition
     ((condition expected-each/the-but-end)
      stream
-     (language cleavir-i18n:english))
+     (language acclimation:english))
   (declare (ignorable condition))
   (format stream
 	  "Expected the loop keyword each/the,~@
            but reached the end of the loop body."))
 
-(defmethod cleavir-i18n:report-condition
+(defmethod acclimation:report-condition
     ((condition expected-each/the-but-found)
      stream
-     (language cleavir-i18n:english))
+     (language acclimation:english))
   (format stream
 	  "Expected the loop keyword each/the, but found~@
            the following instead:~@
            ~s"
 	  (found condition)))
 
-(defmethod cleavir-i18n:report-condition
+(defmethod acclimation:report-condition
     ((condition expected-hash-or-package-but-end)
      stream
-     (language cleavir-i18n:english))
+     (language acclimation:english))
   (declare (ignorable condition))
   (format stream
 	  "Expected a loop keyword indicating a for/as-hash,~@
            but reached the end of the loop body."))
 
-(defmethod cleavir-i18n:report-condition
+(defmethod acclimation:report-condition
     ((condition expected-hash-or-package-but-found)
      stream
-     (language cleavir-i18n:english))
+     (language acclimation:english))
   (format stream
 	  "Expected a loop keyword indicating a for/as-hash~@
            or a for/as-package subclause, but found~@
@@ -188,86 +188,86 @@
            ~s"
 	  (found condition)))
 
-(defmethod cleavir-i18n:report-condition
+(defmethod acclimation:report-condition
     ((condition expected-in/of-but-end)
      stream
-     (language cleavir-i18n:english))
+     (language acclimation:english))
   (declare (ignorable condition))
   (format stream
 	  "Expected the loop keyword in/or,~@
            but reached the end of the loop body."))
 
-(defmethod cleavir-i18n:report-condition
+(defmethod acclimation:report-condition
     ((condition expected-in/of-but-found)
      stream
-     (language cleavir-i18n:english))
+     (language acclimation:english))
   (format stream
 	  "Expected the loop keyword in/or, but found~@
            the following instead:~@
            ~s"
 	  (found condition)))
 
-(defmethod cleavir-i18n:report-condition
+(defmethod acclimation:report-condition
     ((condition expected-hash-key-but-end)
      stream
-     (language cleavir-i18n:english))
+     (language acclimation:english))
   (declare (ignorable condition))
   (format stream
 	  "Expected (hash-key other-var),~@
            but reached the end of the loop body."))
 
-(defmethod cleavir-i18n:report-condition
+(defmethod acclimation:report-condition
     ((condition expected-hash-value-but-end)
      stream
-     (language cleavir-i18n:english))
+     (language acclimation:english))
   (declare (ignorable condition))
   (format stream
 	  "Expected (hash-value other-var),~@
            but reached the end of the loop body."))
 
-(defmethod cleavir-i18n:report-condition
+(defmethod acclimation:report-condition
     ((condition expected-hash-key-but-found)
      stream
-     (language cleavir-i18n:english))
+     (language acclimation:english))
   (format stream
 	  "Expected (hash-key other-var), but found~@
            the following instead:~@
            ~s"
 	  (found condition)))
 
-(defmethod cleavir-i18n:report-condition
+(defmethod acclimation:report-condition
     ((condition expected-hash-value-but-found)
      stream
-     (language cleavir-i18n:english))
+     (language acclimation:english))
   (format stream
 	  "Expected (hash-value other-var), but found~@
            the following instead:~@
            ~s"
 	  (found condition)))
 
-(defmethod cleavir-i18n:report-condition
+(defmethod acclimation:report-condition
     ((condition expected-preposition-but-end)
      stream
-     (language cleavir-i18n:english))
+     (language acclimation:english))
   (declare (ignorable condition))
   (format stream
 	  "Expected a for/as preposition,~@
            but reached the end of the loop body."))
 
-(defmethod cleavir-i18n:report-condition
+(defmethod acclimation:report-condition
     ((condition too-many-prepositions-from-one-group)
      stream
-     (language cleavir-i18n:english))
+     (language acclimation:english))
   (format stream
 	  "Expected (hash-value other-var), but found~@
            the following instead:~@
            ~s"
 	  (found condition)))
 
-(defmethod cleavir-i18n:report-condition
+(defmethod acclimation:report-condition
     ((condition conflicting-stepping-directions)
      stream
-     (language cleavir-i18n:english))
+     (language acclimation:english))
   (declare (ignorable condition))
   (format stream
 	  "Conflicting stepping directions."))
@@ -276,27 +276,27 @@
 ;;;
 ;;; Condition reporters for syntax errors.
 
-(defmethod cleavir-i18n:report-condition
+(defmethod acclimation:report-condition
     ((condition name-clause-not-first)
      stream
-     (language cleavir-i18n:english))
+     (language acclimation:english))
   (declare (ignorable condition))
   (format stream
 	  "A NAME loop clause was found, but it was~@
            not the first clause."))
 
-(defmethod cleavir-i18n:report-condition
+(defmethod acclimation:report-condition
     ((condition multiple-name-clauses)
      stream
-     (language cleavir-i18n:english))
+     (language acclimation:english))
   (declare (ignorable condition))
   (format stream
 	  "Multiple NAME clauses where found."))
 
-(defmethod cleavir-i18n:report-condition
+(defmethod acclimation:report-condition
     ((condition multiple-variable-occurrences)
      stream
-     (language cleavir-i18n:english))
+     (language acclimation:english))
   (format stream
 	  "Multiple occurrences of the following variable were found:~@
            ~s"

--- a/Code/Loop/run-time-conditions.lisp
+++ b/Code/Loop/run-time-conditions.lisp
@@ -1,6 +1,6 @@
 (cl:in-package #:sicl-loop)
 
-(define-condition loop-runtime-error (error cleavir-i18n:condition)
+(define-condition loop-runtime-error (error acclimation:condition)
   ())
 
 (define-condition sum-argument-must-be-number (type-error loop-runtime-error)

--- a/Code/Reader/Fast/condition-reporters-english.lisp
+++ b/Code/Reader/Fast/condition-reporters-english.lisp
@@ -1,35 +1,35 @@
 (cl:in-package #:sicl-read)
 
-(defmethod cleavir-i18n:report-condition
+(defmethod acclimation:report-condition
     ((condition unmatched-right-parenthesis)
      stream
-     (language cleavir-i18n:english))
+     (language acclimation:english))
   (format stream "Unmatched right parenthesis found."))
 
-(defmethod cleavir-i18n:report-condition
+(defmethod acclimation:report-condition
     ((condition only-dots-in-token)
      stream
-     (language cleavir-i18n:english))
+     (language acclimation:english))
   (format stream "A token with only dots in it was found"))
 
-(defmethod cleavir-i18n:report-condition
+(defmethod acclimation:report-condition
     ((condition single-dot-token)
      stream
-     (language cleavir-i18n:english))
+     (language acclimation:english))
   (format stream "A token consisting of a single dot was found ~@
                   in a context that does not permit such a token."))
 
-(defmethod cleavir-i18n:report-condition
+(defmethod acclimation:report-condition
     ((condition no-object-preceding-dot)
      stream
-     (language cleavir-i18n:english))
+     (language acclimation:english))
   (format stream "A left parenthesis cannot be ~
                   immediately followed by a dot"))
 
-(defmethod cleavir-i18n:report-condition
+(defmethod acclimation:report-condition
     ((condition multiple-objects-following-dot)
      stream
-     (language cleavir-i18n:english))
+     (language acclimation:english))
   (format stream "A second expression following a dot~@
                   inside a list was found: ~S."
 	  (offending-expression condition)))

--- a/Code/Reader/Fast/conditions.lisp
+++ b/Code/Reader/Fast/conditions.lisp
@@ -1,6 +1,6 @@
 (cl:in-package #:sicl-read)
 
-(define-condition sicl-reader-error (reader-error cleavir-i18n:condition)
+(define-condition sicl-reader-error (reader-error acclimation:condition)
   ())
 
 (define-condition unmatched-right-parenthesis (sicl-reader-error)

--- a/Code/String/General/condition-reporters-en.lisp
+++ b/Code/String/General/condition-reporters-en.lisp
@@ -16,40 +16,40 @@
 
 (cl:in-package #:sicl-string)
 
-(defmethod cleavir-i18n:report-condition
+(defmethod acclimation:report-condition
     ((c bag-is-dotted-list)
      stream
-     cleavir-i18n:english)
+     acclimation:english)
   (format stream
 	  "If a character bag is a list, it must be a proper list.~@
            But the following dotted list was found instead:~@
            ~s."
 	  (type-error-datum c)))
 
-(defmethod cleavir-i18n:report-condition
+(defmethod acclimation:report-condition
     ((c bag-is-circular-list)
      stream
-     cleavir-i18n:english)
+     acclimation:english)
   (format stream
 	  "If a character bag is a list, it must be a proper list.~@
            But the following circular list was found instead:~@
            ~s."
 	  (type-error-datum c)))
 
-(defmethod cleavir-i18n:report-condition
+(defmethod acclimation:report-condition
     ((c bag-contains-non-character)
      stream
-     cleavir-i18n:english)
+     acclimation:english)
   (format stream
 	  "A character bag must be a sequence that contains only characters.~@
            But the following element was found which is not a character:~@
            ~s."
 	  (type-error-datum c)))
 
-(defmethod cleavir-i18n:report-condition
+(defmethod acclimation:report-condition
     ((c invalid-bounding-indices)
      stream
-     cleavir-i18n:english)
+     acclimation:english)
   (format stream
 	  "In order for START and END to be valid bounding indices,~@
            START must between 0 and the length of the string, and~@

--- a/Code/String/General/conditions.lisp
+++ b/Code/String/General/conditions.lisp
@@ -17,19 +17,19 @@
 (cl:in-package #:sicl-string)
 
 (define-condition bag-is-dotted-list
-    (type-error cleavir-i18n:condition)
+    (type-error acclimation:condition)
   ())
 
 (define-condition bag-is-circular-list
-    (type-error cleavir-i18n:condition)
+    (type-error acclimation:condition)
   ())
 
 (define-condition bag-contains-non-character
-    (type-error cleavir-i18n:condition)
+    (type-error acclimation:condition)
   ())
 
 (define-condition invalid-bounding-indices
-    (error cleavir-i18n:condition)
+    (error acclimation:condition)
   ((%target :initarg :target :reader target)
    (%start :initarg start :reader start)
    (%end :initarg end :reader end)))


### PR DESCRIPTION
Replaced all package nickname prefixes cleavir-i18n with acclimation.