### PR TITLE
AST: lambda-call: sanitize a first lambda  symbol

### DIFF
--- a/Code/Cleavir/Generate-AST/condition-reporters-english.lisp
+++ b/Code/Cleavir/Generate-AST/condition-reporters-english.lisp
@@ -227,3 +227,14 @@
            The following operator was found:~@
            ~s"
 	  (expr condition)))
+
+(defmethod acclimation:report-condition
+    ((condition lambda-call-first-symbol-not-lambda)
+     stream
+     (language acclimation:english))
+  (format stream
+          "Lambda call form was used with the malformed lambda block~@
+          first argument instead of the symbol LAMBDA. The following~@
+          form was found:~@
+          ~s"
+          (expr condition)))

--- a/Code/Cleavir/Generate-AST/conditions.lisp
+++ b/Code/Cleavir/Generate-AST/conditions.lisp
@@ -163,3 +163,9 @@
 (define-condition no-default-method
     (compilation-program-error)
   ((%operator :initarg :operator :reader operator)))
+
+;;; This condition is signaled when a LAMBDA-CALL expression is
+;;; encountered, but the first symbol isn't LAMBDA.
+(define-condition lambda-call-first-symbol-not-lambda
+    (compilation-program-error)
+  ())

--- a/Code/Cleavir/Generate-AST/generate-ast.lisp
+++ b/Code/Cleavir/Generate-AST/generate-ast.lisp
@@ -128,7 +128,8 @@
 
 (defmethod convert-lambda-call (form env system)
   (destructuring-bind ((lambda lambda-list &rest body) &rest args) form
-    (declare (ignore lambda))
+    (assert (eql lambda 'cl:lambda) nil
+            'lambda-call-first-symbol-not-lambda :expr lambda)
     (cleavir-ast:make-call-ast
      (convert-code lambda-list body env system)
      (convert-sequence args env system))))


### PR DESCRIPTION
Appropriate condition has been created with the english report
message. Sanity check is achieved with the assertion in
convert-lambda-call.