### PR TITLE
Fix AST interpreter and a few error messages

### DIFF
--- a/Code/Cleavir/Abstract-syntax-tree/packages.lisp
+++ b/Code/Cleavir/Abstract-syntax-tree/packages.lisp
@@ -16,7 +16,8 @@
    #:constant-ast #:make-constant-ast #:value
    #:lexical-ast #:make-lexical-ast
    #:symbol-value-ast #:make-symbol-value-ast
-   #:set-symbol-value-ast #:make-set-symbol-value-ast #:symbol-ast
+   #:set-symbol-value-ast #:make-set-symbol-value-ast
+   #:symbol #:symbol-ast
    #:fdefinition-ast #:make-fdefinition-ast #:info #:name-ast
    #:call-ast #:make-call-ast #:callee-ast #:argument-asts
    #:block-ast #:make-block-ast #:body

--- a/Code/Cleavir/Generate-AST/condition-reporters-english.lisp
+++ b/Code/Cleavir/Generate-AST/condition-reporters-english.lisp
@@ -224,7 +224,7 @@
            Client code must either define these operators as macros,~@
            or supply a method on CONVERT-SPECIAL, specialized to the~@
            name of the operator and to the implementation-specific environment.~@
-           The following operator was found:~@
+           The following form was found:~@
            ~s"
 	  (expr condition)))
 

--- a/Code/Cleavir/Generate-AST/convert-special.lisp
+++ b/Code/Cleavir/Generate-AST/convert-special.lisp
@@ -746,20 +746,20 @@
 
 (defmethod convert-special
     ((symbol (eql 'unwind-protect)) form environment system)
-  (declare (ignore form environment system))
-  (error 'no-default-method :operator symbol))
+  (declare (ignore environment system))
+  (error 'no-default-method :operator symbol :expr form))
 
 (defmethod convert-special
     ((symbol (eql 'catch)) form environment system)
-  (declare (ignore form environment system))
-  (error 'no-default-method :operator symbol))
+  (declare (ignore environment system))
+  (error 'no-default-method :operator symbol :expr form))
 
 (defmethod convert-special
     ((symbol (eql 'throw)) form environment system)
-  (declare (ignore form environment system))
-  (error 'no-default-method :operator symbol))
+  (declare (ignore environment system))
+  (error 'no-default-method :operator symbol :expr form))
 
 (defmethod convert-special
     ((symbol (eql 'progv)) form environment system)
-  (declare (ignore form environment system))
-  (error 'no-default-method :operator symbol))
+  (declare (ignore environment system))
+  (error 'no-default-method :operator symbol :expr form))


### PR DESCRIPTION
The AST interpreter seemed to rely on old definitions for a few ASTs, e.g. symbol-value-ast was expected to have a constant rather than an ast. Also, it relied on SHADOW being exported from cleavir-ast, so I put that export in. Also added M-V-C interpretation.

The error messages for the undefined convert-specials are wrong. If you actually have one of those errors signalled, the debugger will report that it ran into an error trying to print the error report - because the condition reporters rely on EXPR being bound. So now EXPR is bound.