### PR TITLE
More inlining

### DIFF
--- a/Code/Cleavir/Environment/augmentation-functions.lisp
+++ b/Code/Cleavir/Environment/augmentation-functions.lisp
@@ -29,3 +29,5 @@
 (defgeneric add-optimize (environment quality value))
 
 (defgeneric add-inline (environment function-name inline))
+
+(defgeneric add-inline-expansion (environment function-name expansion))

--- a/Code/Cleavir/Environment/default-augmentation-classes.lisp
+++ b/Code/Cleavir/Environment/default-augmentation-classes.lisp
@@ -349,3 +349,28 @@
   (print-unreadable-object (object stream :type t :identity t)
     (format stream "~s ~s" (name object) (inline object))))
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;
+;;;
+;;; INLINE-EXPANSION.
+
+;;; This class is used to augment an environment with an inline
+;;; expansion for a function (i.e., the :ast initarg to
+;;; local- and global-function-info).
+;;; It is separate from INLINE because having an expansion doesn't
+;;; mean using it, and separate from the defining info because
+;;; sometimes you have the name but want to add the expansion lower
+;;; down.
+(defclass inline-expansion (entry)
+  ((%name :initarg :name :reader name)
+   (%ast :initarg :ast :reader ast)))
+
+(defmethod add-inline-expansion (environment function-name expansioN)
+  (make-instance 'inline-expansion
+    :next environment
+    :name function-name
+    :ast expansion))
+
+(defmethod print-object ((object inline-expansion) stream)
+  (print-unreadable-object (object stream :type t :identity t)
+    (format stream "~s" (name object))))

--- a/Code/Cleavir/Environment/default-info-methods.lisp
+++ b/Code/Cleavir/Environment/default-info-methods.lisp
@@ -663,8 +663,8 @@
 ;;; entry that resulted in the creation of the defining info.  If the
 ;;; names are not the same, we continue the search.
 
-(defmethod function-inline ((environment function)
-			  (defining-info local-function-info))
+(defmethod function-inline-expansion
+    ((environment function) (defining-info local-function-info))
   (if (equal (name environment) (name defining-info))
       nil
       (function-inline-expansion (next environment) defining-info)))

--- a/Code/Cleavir/Environment/default-info-methods.lisp
+++ b/Code/Cleavir/Environment/default-info-methods.lisp
@@ -581,7 +581,7 @@
 ;;;
 ;;; This function takes an environment and a defining info instance
 ;;; and returns the first entry in the environment that contains inline
-;;; information for the defining info instance, or NIL if there is not
+;;; information for the defining info instance, or NIL if there is no
 ;;; such entry.
 
 (defgeneric function-inline (environment defining-info))
@@ -590,7 +590,7 @@
 ;;; environment.
 (defmethod function-inline (environment defining-info)
   (declare (cl:ignore environment))
-  (inline defining-info))
+  nil)
 
 ;;; This method is called when the entry is not related to the
 ;;; defining info instance. 
@@ -632,6 +632,59 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;
+;;; Generic function FUNCTION-INLINE-EXPANSION.
+;;;
+;;; This function takes an environment and a defining info instance
+;;; and returns the first entry in the environment that contains
+;;; an expansion for the defining info instance, or NIL if there is
+;;; no such entry.
+
+(defgeneric function-inline-expansion (environment defining-info))
+
+;;; This method is called when the environment is the global
+;;; environment.
+(defmethod function-inline-expansion (environment defining-info)
+  (declare (cl:ignore environment))
+  nil)
+
+;;; This method is called when the entry is not related to the
+;;; defining info instance. 
+(defmethod function-inline-expansion
+    ((environment entry) defining-info)
+  (declare (cl:ignorable environment defining-info))
+  (function-inline-expansion (next environment) defining-info))
+
+;;; The following method is called when the environment entry is of
+;;; the same type as the one that resulted in the creation of the
+;;; defining info instance.  If the name of the environment entry is
+;;; the same as the name of the info instance, then this entry was the
+;;; one that resulted in the creation of the defining info instance.
+;;; In other words, we have found no function type entries before
+;;; entry that resulted in the creation of the defining info.  If the
+;;; names are not the same, we continue the search.
+
+(defmethod function-inline ((environment function)
+			  (defining-info local-function-info))
+  (if (equal (name environment) (name defining-info))
+      nil
+      (function-inline-expansion (next environment) defining-info)))
+
+;;; The following method is called when the current entry is a
+;;; candidate for being the entry containing inline information for a
+;;; function info.  We found the right one if the names are the same.
+;;; If not, then we continue the search.
+
+(defmethod function-inline-expansion
+    ((environment inline-expansion)
+     (defining-info local-function-info))
+  (if (equal (name environment) (name defining-info))
+      environment
+      (function-inline-expansion (next environment) defining-info)))
+
+;;; No inline-expansions for global function infos.
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;
 ;;; Methods on MAKE-INFO specialized to INFO classes returned by
 ;;; FUNCTION-INFO.
 
@@ -643,7 +696,14 @@
     :type (cons 'and (function-type environment defining-info))
     :ignore
     (let ((entry (function-ignore environment defining-info)))
-      (if (null entry) nil (ignore entry)))
+      (ignore (or entry defining-info)))
+    :inline
+    (let ((entry (function-inline environment defining-info)))
+      (inline (or entry defining-info)))
+    :ast
+    (let ((entry (function-inline-expansion environment
+					    defining-info)))
+      (ast (or entry defining-info)))
     :dynamic-extent
     (let ((entry (function-dynamic-extent environment defining-info)))
       (if (null entry) (dynamic-extent defining-info) t))))
@@ -655,8 +715,12 @@
     :type (cons 'and (function-type environment defining-info))
     :ignore
     (let ((entry (function-ignore environment defining-info)))
-      (if (null entry) nil (ignore entry)))
-    :inline (function-inline environment defining-info)
+      (ignore (or entry defining-info)))
+    :inline
+    (let ((entry (function-inline environment defining-info)))
+      (inline (or entry defining-info)))
+    ;; don't bother with function-inline-expansion, since there
+    ;;  shouldn't be local expansions for global functions.
     :ast (ast defining-info)
     :compiler-macro (compiler-macro defining-info)
     :dynamic-extent

--- a/Code/Cleavir/Environment/packages.lisp
+++ b/Code/Cleavir/Environment/packages.lisp
@@ -71,6 +71,7 @@
    #:add-function-dynamic-extent
    #:add-optimize
    #:add-inline
+   #:add-inline-expansion
    #:eval
    #:macro-function
    #:compiler-macro-function

--- a/Code/Cleavir/Environment/query.lisp
+++ b/Code/Cleavir/Environment/query.lisp
@@ -127,7 +127,8 @@
    ;; NOTINLINE declaration in scope.  INLINE means that there is an
    ;; INLINE declaration in scope, and NOTINLINE means that there is a
    ;; NOTINLINE declaration in scope.
-   (%inline :initform nil :initarg :inline :reader inline)
+   (%inline :initform nil :initarg :inline :reader inline
+	    :type (member nil inline notinline))
    ;; There are three possible values here, namely NIL, IGNORE, and
    ;; IGNORABLE.  NIL means that no IGNORE information has been
    ;; supplied.  IGNORE means and IGNORE declaration is in scope, and
@@ -157,7 +158,8 @@
    ;; NOTINLINE declaration in scope.  INLINE means that there is an
    ;; INLINE declaration in scope, and NOTINLINE means that there is a
    ;; NOTINLINE declaration in scope.
-   (%inline :initform nil :initarg :inline :reader inline)
+   (%inline :initform nil :initarg :inline :reader inline
+	    :type (member nil inline notinline))
    ;; If the value of this slot is NIL, it means that there is no
    ;; compiler macro associated with this function.  If not, the value
    ;; must be a compiler macro function.

--- a/Code/Cleavir/Generate-AST/convert-form.lisp
+++ b/Code/Cleavir/Generate-AST/convert-form.lisp
@@ -130,9 +130,7 @@
 
 (defmethod convert-form
     (form (info cleavir-env:local-function-info) env system)
-  (let ((function-ast (cleavir-env:identity info))
-	(argument-asts (convert-sequence (cdr form) env system)))
-    (cleavir-ast:make-call-ast function-ast argument-asts)))
+  (make-call info env (cdr form) system))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;
@@ -177,7 +175,7 @@
 	         else
 		   collect (cleavir-ast:make-setq-ast
 			    (second parameter)
-			    (generate-ast nil env system))
+			    (convert nil env system))
 	  else do (return-from inline-lambda-init (noinline)))))
 
 (defun make-call (info env arguments system)

--- a/Code/Cleavir/Generate-AST/convert-form.lisp
+++ b/Code/Cleavir/Generate-AST/convert-form.lisp
@@ -187,6 +187,7 @@ This function should not require an environment or system, but it unfortunately 
 		   and collect (cleavir-ast:make-setq-ast
 				(first parameter)
 				(second parameter))
+		   and do (setf arg-asts (rest arg-asts))
 	         else
 		   collect (cleavir-ast:make-setq-ast
 			    (second parameter)

--- a/Code/Cleavir/Generate-AST/convert-special.lisp
+++ b/Code/Cleavir/Generate-AST/convert-special.lisp
@@ -354,7 +354,8 @@
 			 collect (cons (first def)
 				       (convert-local-function
 					def outer-env system))))
-	     (inner-env (augment-environment-with-asts env defs))
+	     (inner-env (augment-environment-with-asts
+			 outer-env defs))
 	     (init-asts
 	       (compute-function-init-asts defs inner-env))
 	     (inner-env (augment-environment-with-declarations


### PR DESCRIPTION
This adds two things: inlinable local functions, and inlinable functions with complicated lambda lists (but still not &key).

The former is accomplished by a protocol change: a new function cleavir-env:add-inline-expansion and accompanying junk. add-inline-expansion works pretty much like add-function-type, but with a different class and controlling the :ast initarg to function infos. It also involves rewriting convert-special on flet and labels.

The latter is more localized, and just means rewriting the local function make-call, and adding a new internal function, inline-lambda-init. It's kind of twisted but I don't know a better way to do it. Probably the most concerning part is the generation of a call to cl:list.

Finally I threw in a few tests. They're not wholly covering by any means (no shadowing or global inlined functions), but a good start I think.