### PR TITLE
generate-ast: integers are go tags too

### DIFF
--- a/Code/Cleavir/Generate-AST/convert-special.lisp
+++ b/Code/Cleavir/Generate-AST/convert-special.lisp
@@ -739,7 +739,9 @@
     (let ((tag-asts
 	    (loop for item in (raw items)
 		  for raw-item = (raw item)
-		  when (symbolp raw-item)
+		  ;; go tags are symbols or integers, per CLHS glossary.
+		  when (or (symbolp raw-item)
+			   (integerp raw-item))
 		    collect (cleavir-ast:make-tag-ast
 			     raw-item
 			     :origin (location item))))


### PR DESCRIPTION
checked random things while checking something else, and hey: code from 1974 wouldn't be able to run

that is, go tags in tagbodies can be symbols but also integers