### PR TITLE
Type inference: fix rare issue with duplicate predecessors

### DIFF
--- a/Code/Cleavir/Type-inference/type-inference.lisp
+++ b/Code/Cleavir/Type-inference/type-inference.lisp
@@ -14,7 +14,8 @@
 	(result (make-dictionary)))
     (cleavir-ir:map-instructions-arbitrary-order
      (lambda (instruction)
-       (loop for predecessor in (cleavir-ir:predecessors instruction)
+       (loop for predecessor in (remove-duplicates
+				 (cleavir-ir:predecessors instruction))
 	     for live = (cleavir-liveness:live-before liveness instruction)
 	     do (loop for var in live
 		      when (typep var 'cleavir-ir:lexical-location)


### PR DESCRIPTION
drmeister (clasp) ran into some code with an eq instruction where both
successors fed to the same assignment instruction. That's kind of weird
but understandable. But it broke type inference, because the bags
produced by compute-initial-dictionary had duplicate location entries.

I had drmeister duct-tape it with pushnew instead, but removing
duplicates is probably more correct. (Also probably slower :/)