### PR TITLE
generate-AST: obey notinline with respect to compiler macros

### DIFF
--- a/Code/Cleavir/Generate-AST/convert-form.lisp
+++ b/Code/Cleavir/Generate-AST/convert-form.lisp
@@ -360,8 +360,9 @@ This function should not require an environment or system, but it unfortunately 
   ;; evaluate the form.
   (when (and *current-form-is-top-level-p* *compile-time-too*)
     (cleavir-env:eval form env env))
-  (let ((compiler-macro (cleavir-env:compiler-macro info)))
-    (if (null compiler-macro)
+  (let ((compiler-macro (cleavir-env:compiler-macro info))
+	(notinline (eq 'notinline (cleavir-env:inline info))))
+    (if (or notinline (null compiler-macro))
 	;; There is no compiler macro.  Create the call.
 	(make-call info env (cdr form) system)
 	;; There is a compiler macro.  We must see whether it will

--- a/Code/Cleavir/Generate-AST/convert-special.lisp
+++ b/Code/Cleavir/Generate-AST/convert-special.lisp
@@ -211,7 +211,10 @@
 		       new-env canonicalized-dspecs)))
 	(process-progn
 	 (append init-asts
-		 (convert-sequence forms new-env system)))))))
+		 ;; so that flet with empty body works.
+		 (list
+		  (process-progn
+		   (convert-sequence forms new-env system)))))))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;
@@ -361,8 +364,11 @@
 	     (inner-env (augment-environment-with-declarations
 			 inner-env canonicalized-dspecs)))
 	(process-progn
-	 (append init-asts
-		 (convert-sequence forms inner-env system)))))))
+	 (append
+	  init-asts
+	  (list
+	   (process-progn
+	    (convert-sequence forms inner-env system)))))))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;


### PR DESCRIPTION
a local notinline declaration suppresses compiler macro expansion per
the entry on notinline.

the choice of whether to expand is one of those things that should
probably have more specific customization protocols in the future.