### PR TITLE
type inference: detect compute-initial-dictionary problem and signal

### DIFF
--- a/Code/Cleavir/Type-inference/packages.lisp
+++ b/Code/Cleavir/Type-inference/packages.lisp
@@ -7,4 +7,6 @@
 	   #:binary-join #:binary-meet #:difference
 	   #:join #:meet)
   (:export #:infer-types #:arc-bag
-	   #:instruction-input #:find-type))
+	   #:instruction-input #:find-type)
+  (:export #:type-missing
+	   #:type-missing-location #:type-missing-bag))

--- a/Code/Cleavir/Type-inference/update.lisp
+++ b/Code/Cleavir/Type-inference/update.lisp
@@ -5,9 +5,25 @@
 	(remove location bag
 		:test #'eq :key #'first)))
 
+;;; if you are seeing this error and looking for the cause:
+;;; compute-initial-dictionary should give every location a type of
+;;;  T in every arc that location is live in. It is not doing so.
+(define-condition type-missing (error)
+  ((location :initarg :location :reader type-missing-location)
+   (bag :initarg :bag :reader type-missing-bag))
+  (:report
+   (lambda (condition stream)
+     (format stream "No type information for location ~s in bag ~s.
+This is probably an internal bug in type inference (or related systems, e.g. liveness)."
+             (type-missing-location condition)
+             (type-missing-bag condition)))))
+
 (defgeneric find-type (location bag)
   (:method (location bag)
-    (cdr (assoc location bag :test #'eq))))
+    (let ((a (assoc location bag :test #'eq)))
+      (if a
+          (cdr a)
+          (error 'type-missing :location location :bag bag)))))
 (defmethod find-type
     ((location cleavir-ir:constant-input) bag)
   (declare (ignore bag))


### PR DESCRIPTION
Currently liveness is broken such that type inference will return an
empty dictionary for certain kinds of loops. That will be difficult to
fix, but in the meantime, find-type should not treat "no information" as
"it's of type NIL" as it did before it commit: it should signal an error
saying that type inference did not work.