### PR TITLE
liveness: replace recursion with iteration

### DIFF
--- a/Code/Compiler/sicl-compiler.asd
+++ b/Code/Compiler/sicl-compiler.asd
@@ -4,8 +4,7 @@
   :depends-on (:cleavir-code-utilities
 	       :sicl-global-environment
 	       :sicl-reader-simple
-	       :sicl-generate-ast
-	       :sicl-type
+	       :cleavir-generate-ast
 	       :cleavir-ast
 	       :cleavir-primop)
   :serial t

--- a/Code/Conditions/conditions.lisp
+++ b/Code/Conditions/conditions.lisp
@@ -2,7 +2,7 @@
 
 (define-condition condition () ())
 
-(defparameter *langauge* 'english)
+(defparameter *language* 'english)
 
 (defgeneric report-condition (condition stream language))
 


### PR DESCRIPTION
This commit also removes "transparent" fucntion definitions (for
instance `cleavir-ir:inputs` -> `inputs` - we use full package qualifiers there).