### PR TITLE
Fix local function inlining (hopefully)

### DIFF
--- a/Code/Cleavir/AST-transformations/clone.lisp
+++ b/Code/Cleavir/AST-transformations/clone.lisp
@@ -42,8 +42,14 @@
 ;;; If the substructure of an AST is another AST, then the
 ;;; corresponding substructure of the new AST is obtained from the
 ;;; dictionary.
+;;; If it's not in the dictionary, it is not part of the AST being
+;;; cloned, e.g. because it's an outer block. So use the original.
 (defmethod finalize-substructure ((object cleavir-ast:ast) dictionary)
-  (gethash object dictionary))
+  (multiple-value-bind (ast present-p)
+      (gethash object dictionary)
+    (if present-p
+	ast
+	object)))
 
 ;;; Given an AST to finalize and the MODEL AST of which the AST is a
 ;;; clone,  reinitialize the AST with new substructure.
@@ -88,7 +94,11 @@
 	 ,(codegen-finalize-substructure (cdr object) dictionary)))
 
 (defmethod codegen-finalize-substructure ((object cleavir-ast:ast) dictionary)
-  (gethash object dictionary))
+  (multiple-value-bind (ast present-p)
+      (gethash object dictionary)
+    (if present-p
+	ast
+	object)))
 
 (defun codegen-finalize (model dictionary)
   `(reinitialize-instance

--- a/Code/Cleavir/Abstract-syntax-tree/general-purpose-asts.lisp
+++ b/Code/Cleavir/Abstract-syntax-tree/general-purpose-asts.lisp
@@ -426,7 +426,7 @@
   (:form-ast form-ast))
 
 (defmethod children ((ast return-from-ast))
-  (list (block-ast ast) (form-ast ast)))
+  (list (form-ast ast)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;


### PR DESCRIPTION
In the event that a local function marked for inlining refers to ASTs
not in the function body, such as a block or go tag, those ASTs should
be referred to directly instead of being cloned. This patch should
accomplish that.

Example compile failure before this patch:
(block nil
  (flet ((foo () (return nil)))
    (declare (inline foo))
    (foo)))

This fixes some things, but I'm not totally confident that it fully
fixes the problem and doesn't add issues elsewhere, because the issue
arose in Clasp loading PPCRE (drmeister/clasp#319). This patch lets
PPCRE load, but it still doesn't work, and I don't know if that problem
is related.