### PR TITLE
Fix fallout from adding AST slot

### DIFF
--- a/Code/Cleavir/Abstract-syntax-tree/general-purpose-asts.lisp
+++ b/Code/Cleavir/Abstract-syntax-tree/general-purpose-asts.lisp
@@ -37,6 +37,10 @@
   ((%origin :initform nil :initarg :origin :accessor origin)
    (%policy :initform *policy* :initarg :policy :accessor policy)))
 
+;;; Policies must be saved
+(cleavir-io:define-save-info ast
+  (:policy policy))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;
 ;;; Mixin classes.

--- a/Code/Cleavir/Abstract-syntax-tree/general-purpose-asts.lisp
+++ b/Code/Cleavir/Abstract-syntax-tree/general-purpose-asts.lisp
@@ -634,7 +634,9 @@
 (defmethod type-specifier-ast :around ((ast typeq-ast))
   (let ((value (call-next-method)))
     (when (null value)
-      (setq value (make-load-time-value-ast `',(type-specifier ast)))
+      (setq value (make-load-time-value-ast
+		   `',(type-specifier ast) t
+		   :policy (cleavir-ast:policy ast)))
       (reinitialize-instance
        ast
        :type-specifier-ast value))

--- a/Code/Cleavir/HIR-transformations/coalesce-load-time-values.lisp
+++ b/Code/Cleavir/HIR-transformations/coalesce-load-time-values.lisp
@@ -2,7 +2,8 @@
 
 (defun coalesce-load-time-values (initial-instruction)
   (check-type initial-instruction cleavir-ir:top-level-enter-instruction)
-  (let ((table (make-hash-table :test #'equal)))
+  (let ((table (make-hash-table :test #'equal))
+	(cleavir-ir:*policy* (cleavir-ir:policy initial-instruction)))
     (cleavir-ir:map-instructions-arbitrary-order
      (lambda (instruction)
        (loop for input in (cleavir-ir:inputs instruction)

--- a/Code/Cleavir/HIR-transformations/eliminate-typeq.lisp
+++ b/Code/Cleavir/HIR-transformations/eliminate-typeq.lisp
@@ -7,7 +7,8 @@
   nil)
 
 (defmethod maybe-eliminate ((instruction cleavir-ir:typeq-instruction))
-  (let* ((object (first (cleavir-ir:inputs instruction)))
+  (let* ((cleavir-ir:*policy* (cleavir-ir:policy instruction))
+	 (object (first (cleavir-ir:inputs instruction)))
 	 (typep-constant (cleavir-ir:make-constant-input 'typep))
 	 (typep-function (cleavir-ir:new-temporary))
 	 (fdefinition (cleavir-ir:make-fdefinition-instruction

--- a/Code/Cleavir/Path-replication/rewrite.lisp
+++ b/Code/Cleavir/Path-replication/rewrite.lisp
@@ -19,6 +19,7 @@
 	  (loop for predecessor in (cleavir-ir:predecessors instruction)
 		for successors = (cleavir-ir:successors predecessor)
 		for copy = (make-instance (class-of instruction)
+			     :policy (cleavir-ir:policy instruction)
 			     :predecessors (list predecessor)
 			     :successors (cleavir-ir:successors instruction)
 			     :inputs (cleavir-ir:inputs instruction)

--- a/Code/Cleavir/SSA-form/ssa-form.lisp
+++ b/Code/Cleavir/SSA-form/ssa-form.lisp
@@ -129,7 +129,9 @@
 		       do (traverse dominee variable))))))
       (traverse top-node original-variable))
     (loop for (node output . inputs) in funs
-	  collect (cleavir-ir:make-phi-instruction inputs output node)
+	  collect (let ((cleavir-ir:*policy*
+			  (cleavir-ir:policy node)))
+		    (cleavir-ir:make-phi-instruction inputs output node))
 	  finally (incf *ssa2-call-count*)
 		  (incf *ssa2-run-time* (- (get-internal-run-time) time)))))
 


### PR DESCRIPTION
adding that stuff for policies has more consequences. mea culpa.

specifically, in places where ASTs and instructions are created outside of generate-ast or ast-to-hir, policies have to be specified. this is basically in various transforms. i did it for the type transforms but not for other ones, so i did some grepping and it should be ok now.

also policies have to be duped for cloning so that too.