### PR TITLE
Values types

### DIFF
--- a/Code/Cleavir/AST-to-HIR/compile-general-purpose-asts.lisp
+++ b/Code/Cleavir/AST-to-HIR/compile-general-purpose-asts.lisp
@@ -185,10 +185,6 @@
 ;;; *BLOCK-INFO* hash table using the block-ast as a key, so that a
 ;;; RETURN-FROM-AST that refers to this block can be compiled in the
 ;;; same context.
-;;;
-;;; FIXME: we should make sure the context we store is one that has a
-;;; single successor.  If this BLOCK-AST was compiled in a context
-;;; with two successors, we should create a new context for it.
 
 (defparameter *block-info* nil)
 
@@ -687,20 +683,7 @@
 			 (list (cleavir-ir:make-multiple-to-fixed-instruction
 				values-temp results (first successors)))))))
 		(2
-		 (let* ((temp (cleavir-ir:new-temporary))
-			(values-temp (make-instance 'cleavir-ir:values-location))
-			(false (cleavir-ir:make-constant-input nil)))
-		   (make-instance 'cleavir-ir:multiple-value-call-instruction
-		     :inputs (cons function-temp form-temps)
-		     :outputs (list values-temp)
-		     :successors
-		     (list (cleavir-ir:make-multiple-to-fixed-instruction
-			    values-temp
-			    (list temp)
-			    (make-instance 'cleavir-ir:eq-instruction
-			      :inputs (list temp false)
-			      :outputs '()
-			      :successors (reverse successors))))))))))
+		 (error "MULTIPLE-VALUE-CALL-AST appears in a Boolean context.")))))
 	(loop for form-ast in (reverse (cleavir-ast:form-asts ast))
 	      for form-temp in (reverse form-temps)
 	      do (setf successor

--- a/Code/Cleavir/AST-to-source/ast-to-source.lisp
+++ b/Code/Cleavir/AST-to-source/ast-to-source.lisp
@@ -128,3 +128,8 @@
 	      when (typep item 'cleavir-ast:tag-ast)
 		collect (cleavir-ast:name item)
 	      else collect (to-source item dictionary))))
+
+(defmethod to-source ((ast cleavir-ast:values-ast) dictionary)
+  `(cleavir-primop:values ,@(list-to-sources
+			     (cleavir-ast:children ast)
+			     dictionary)))

--- a/Code/Cleavir/Abstract-syntax-tree/general-purpose-asts.lisp
+++ b/Code/Cleavir/Abstract-syntax-tree/general-purpose-asts.lisp
@@ -821,7 +821,7 @@
 ;;; It has two children.  This AST can only appear in the TEST
 ;;; position of an IF-AST.
 
-(defclass eq-ast (ast)
+(defclass eq-ast (ast boolean-ast-mixin)
   ((%arg1-ast :initarg :arg1-ast :reader arg1-ast)
    (%arg2-ast :initarg :arg2-ast :reader arg2-ast)))
 

--- a/Code/Cleavir/Abstract-syntax-tree/general-purpose-asts.lisp
+++ b/Code/Cleavir/Abstract-syntax-tree/general-purpose-asts.lisp
@@ -741,6 +741,28 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;
+;;; Class VALUES-AST.
+;;;
+;;; This corresponds directly to CLEAVIR-PRIMOP:VALUES,
+;;; and CL:VALUES through it.
+
+(defclass values-ast (ast)
+  ((%argument-asts :initarg :argument-asts :reader argument-asts)))
+
+(defun make-values-ast
+    (argument-asts &key origin (policy *policy*))
+  (make-instance 'values-ast
+    :origin origin :policy policy
+    :argument-asts argument-asts))
+
+(cleavir-io:define-save-info values-ast
+  (:argument-asts argument-asts))
+
+(defmethod children ((ast values-ast))
+  (argument-asts ast))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;
 ;;; Class MULTIPLE-VALUE-PROG1-AST.
 
 (defclass multiple-value-prog1-ast (ast)

--- a/Code/Cleavir/Abstract-syntax-tree/packages.lisp
+++ b/Code/Cleavir/Abstract-syntax-tree/packages.lisp
@@ -29,6 +29,7 @@
    #:if-ast #:make-if-ast #:test-ast #:then-ast #:else-ast
    #:multiple-value-call-ast #:make-multiple-value-call-ast
    #:function-form-ast
+   #:values-ast #:make-values-ast
    #:multiple-value-prog1-ast #:make-multiple-value-prog1-ast
    #:first-form-ast
    #:load-time-value-ast #:make-load-time-value-ast #:read-only-p

--- a/Code/Cleavir/Generate-AST/check-special-form-syntax.lisp
+++ b/Code/Cleavir/Generate-AST/check-special-form-syntax.lisp
@@ -342,6 +342,14 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;
+;;; Checking VALUES.
+
+(defmethod check-special-form-syntax
+    ((head (eql 'cleavir-primop:values)) form)
+  (cleavir-code-utilities:check-form-proper-list form))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;
 ;;; Checking TYPEQ.
 
 (defmethod check-special-form-syntax

--- a/Code/Cleavir/Generate-AST/convert-primop.lisp
+++ b/Code/Cleavir/Generate-AST/convert-primop.lisp
@@ -984,3 +984,22 @@
      :index-ast (convert index env system)
      :element-ast (convert bit env system)
      :origin origin)))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;
+;;; Converting CLEAVIR-PRIMOP:VALUES.
+;;;
+;;; This primitive operation can be used to inline CL:VALUES.
+;;; That is, (cl:values ...) and (cleavir-primop:values ...) are
+;;;  equivalent. The difference is that CL:VALUES is a function.
+;;; This will compile down into a FIXED-TO-MULTIPLE-INSTRUCTION.
+
+(defmethod convert-special
+    ((symbol (eql 'cleavir-primop:values)) form env system)
+  (db origin (op . arguments) form
+    (declare (ignore op))
+    (make-instance 'cleavir-ast:values-ast
+     :argument-asts (mapcar
+		     (lambda (form) (convert form env system))
+		     arguments)
+     :origin origin)))

--- a/Code/Cleavir/Intermediate-representation/HIR/general-purpose-instructions.lisp
+++ b/Code/Cleavir/Intermediate-representation/HIR/general-purpose-instructions.lisp
@@ -198,31 +198,6 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;
-;;; Instruction THE-VALUES-INSTRUCTION.
-;;;
-;;; This is like THE-INSTRUCTION, but takes a VALUES-LOCATION
-;;; as input instead of a lexical one, and correspondingly, a
-;;; (decomposed) values type instead of a single-value type.
-;;; A separate instruction is useful because values locations can
-;;; have an unknown or varying number of values.
-
-(defclass the-values-instruction (instruction one-successor-mixin)
-  ((%required-types :initarg :required :reader required-types)
-   (%optional-types :initarg :optional :reader optional-types)
-   (%rest-type :initarg :rest :reader rest-type)))
-
-(defun make-the-values-instruction (input successor
-				    required optional rest)
-  (make-instance 'the-values-instruction
-    :inputs (list input)
-    :outputs '()
-    :successors (list successor)
-    :required required
-    :optional optional
-    :rest rest))
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;;
 ;;; Instruction CATCH-INSTRUCTION.
 ;;;
 ;;; This instruction is used to mark the stack to be an exit point.

--- a/Code/Cleavir/Intermediate-representation/HIR/multiple-value-related-instructions.lisp
+++ b/Code/Cleavir/Intermediate-representation/HIR/multiple-value-related-instructions.lisp
@@ -65,3 +65,28 @@
     :inputs inputs
     :outputs (list output)
     :successors (if successor-p (list successor) '())))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;
+;;; Instruction THE-VALUES-INSTRUCTION.
+;;;
+;;; This is like THE-INSTRUCTION, but takes a VALUES-LOCATION
+;;; as input instead of a lexical one, and correspondingly, a
+;;; (decomposed) values type instead of a single-value type.
+;;; A separate instruction is useful because values locations can
+;;; have an unknown or varying number of values.
+
+(defclass the-values-instruction (instruction one-successor-mixin)
+  ((%required-types :initarg :required :reader required-types)
+   (%optional-types :initarg :optional :reader optional-types)
+   (%rest-type :initarg :rest :reader rest-type)))
+
+(defun make-the-values-instruction (input successor
+				    required optional rest)
+  (make-instance 'the-values-instruction
+    :inputs (list input)
+    :outputs '()
+    :successors (list successor)
+    :required required
+    :optional optional
+    :rest rest))

--- a/Code/Cleavir/Primop/packages.lisp
+++ b/Code/Cleavir/Primop/packages.lisp
@@ -86,4 +86,5 @@
    #:non-simple-unsigned-byte-16-aset-ast
    #:call-with-variable-bound
    #:let-uninitialized
-   #:funcall))
+   #:funcall
+   #:values))

--- a/Code/Cleavir/Type-inference/Transforms/independent.lisp
+++ b/Code/Cleavir/Type-inference/Transforms/independent.lisp
@@ -18,6 +18,33 @@
     (mapc #'cleavir-ir:delete-instruction death-row))
   initial)
 
+;; make some HIR that will signal a type error, that DATUM
+;;  (a lexical location) is not of type EXPECTED.
+;; The instructions will be self-contained and have the right
+;;  predecessor, but changing the predecessor's successor must be
+;;  done elsewhere. (Because you're probably change-class-ing it.)
+(defun make-type-error (predecessor datum expected)
+  ;; FIXME: programmatic HIR could probably be made nicer.
+  (let* ((fdef (cleavir-ir:new-temporary))
+	 (fdefinition-instruction
+	   (cleavir-ir:make-fdefinition-instruction
+	    (cleavir-ir:make-load-time-value-input ''cl:error)
+	    fdef))
+	 (fnr-instruction
+	   (cleavir-ir:make-funcall-no-return-instruction
+	    (list fdef
+		  (cleavir-ir:make-load-time-value-input ''cl:type-error)
+		  (cleavir-ir:make-load-time-value-input '':datum)
+		  datum
+		  (cleavir-ir:make-load-time-value-input '':expected-type)
+		  (cleavir-ir:make-load-time-value-input
+		   `',expected)))))
+    (cleavir-ir:insert-instruction-before fdefinition-instruction
+					  fnr-instruction)
+    (setf (cleavir-ir:predecessors fdefinition-instruction)
+	  (list predecessor))
+    fdefinition-instruction))
+
 ;;; TODO: SBCL has a middle setting on its insert-type-checks that
 ;;; downgrades types into easily checkable ones like FIXNUM.
 ;;; So a sanity check but not wholly correct. Might be nice.
@@ -27,33 +54,14 @@
 ;;; maybe convert a THE instruction into a TYPEQ instruction,
 ;;; depending on policy
 (defun the->typeq (the-instruction)
-  (let ((policy (cleavir-ir:policy the-instruction)))
-    (when (cleavir-policy:policy-value policy 'insert-type-checks)
-      ;; FIXME: programmatic HIR could probably be made nicer.
-      (let* ((cleavir-ir:*policy* policy) ; copy from base instr
-	     (fdef (cleavir-ir:new-temporary))
-	     (fdefinition-instruction
-	       (cleavir-ir:make-fdefinition-instruction
-		(cleavir-ir:make-load-time-value-input ''cl:error)
-		fdef))
-	     (fnr-instruction
-	       (cleavir-ir:make-funcall-no-return-instruction
-		(list fdef
-		      (cleavir-ir:make-load-time-value-input ''cl:type-error)
-		      (cleavir-ir:make-load-time-value-input '':datum)
+  (change-class
+   the-instruction 'cleavir-ir:typeq-instruction
+   :successors (list (first
+		      (cleavir-ir:successors the-instruction))
+		     (make-type-error
+		      the-instruction
 		      (first (cleavir-ir:inputs the-instruction))
-		      (cleavir-ir:make-load-time-value-input '':expected-type)
-		      (cleavir-ir:make-load-time-value-input
-		       `',(cleavir-ir:value-type the-instruction))))))
-	(cleavir-ir:insert-instruction-before fdefinition-instruction
-					      fnr-instruction)
-	(setf (cleavir-ir:predecessors fdefinition-instruction)
-	      (list the-instruction))
-	(change-class
-	 the-instruction 'cleavir-ir:typeq-instruction
-	 :successors (list (first
-			    (cleavir-ir:successors the-instruction))
-			   fdefinition-instruction))))))
+		      (cleavir-ir:value-type the-instruction)))))
 
 ;; convert all of them. intended for safe code, before type inference.
 (defun thes->typeqs (initial)
@@ -66,3 +74,49 @@
     (mapc #'the->typeq thes)
     ;; we only added some branches, so we don't need to reinitialize etc.
     initial))
+
+;; convert FUNCALL to FUNCALL-NO-RETURN where possible
+;; if SAFE-P, cause a type error if they do return
+;; (which will still cut it off from successors. good, yes?)
+(defun mark-noreturns (initial safe-p)
+  ;; this doesn't actually use inferred type information.
+  ;; it COULD, but i expect that calling a variable function that
+  ;;  must not return is not super common.
+  ;; the main value of this transform is to chop impossible
+  ;;  execution paths; we want to do this as early as possible to
+  ;;  improve the performance of other analyses.
+  ;; there could be another stage after type inference to do it for
+  ;;  variable functions if necessary.
+  (let (thevalueses)
+    (cleavir-ir:map-instructions-arbitrary-order
+     (lambda (i)
+       (when (typep i 'cleavir-ir:the-values-instruction)
+	 (push i thevalueses))))
+    (dolist (i thevalueses)
+      (when (member-if (lambda (type) (subtypep type nil))
+		     (cleavir-ir:required-types i))
+	;; we have a noreturn, can proceed
+	(let ((call (first (cleavir-ir:predecessors i))))
+	  ;; this condition should be always true from AST-to-HIR,
+	  ;;  but we might as well check.
+	  ;; in english, the THE-VALUES is the direct successor of
+	  ;;  a FUNCALL and defines the types of its results.
+	  (when (and (= (length (cleavir-ir:predecessors i)) 1)
+		     (typep call 'cleavir-ir:funcall-instruction)
+		     (eq (first (cleavir-ir:inputs i))
+			 (first (cleavir-ir:outputs call))))
+	    ;; ok, the actual transform
+	    (if safe-p
+		;; FIXME: abstract this?
+		(setf (cleavir-ir:successors call)
+		      ;; FIXME: "expected a value of type NIL" is
+		      ;;  not a good error message.
+		      (list (make-type-error
+			     i (first (cleavir-ir:inputs i)) nil)))
+		(change-class
+		 i 'cleavir-ir:funcall-no-return-instruction
+		 :successors nil :outputs nil)))))))
+  ;; paths are dead. make sure the IR is consistent.
+  (cleavir-ir:set-predecessors initial)
+  (cleavir-ir:reinitialize-data initial)
+  initial)

--- a/Code/Cleavir/Type-inference/Transforms/independent.lisp
+++ b/Code/Cleavir/Type-inference/Transforms/independent.lisp
@@ -25,7 +25,8 @@
 ;;  done elsewhere. (Because you're probably change-class-ing it.)
 (defun make-type-error (predecessor datum expected)
   ;; FIXME: programmatic HIR could probably be made nicer.
-  (let* ((fdef (cleavir-ir:new-temporary))
+  (let* ((cleavir-ir:*policy* (cleavir-ir:policy predecessor))
+	 (fdef (cleavir-ir:new-temporary))
 	 (fdefinition-instruction
 	   (cleavir-ir:make-fdefinition-instruction
 	    (cleavir-ir:make-load-time-value-input ''cl:error)
@@ -91,7 +92,8 @@
     (cleavir-ir:map-instructions-arbitrary-order
      (lambda (i)
        (when (typep i 'cleavir-ir:the-values-instruction)
-	 (push i thevalueses))))
+	 (push i thevalueses)))
+     initial)
     (dolist (i thevalueses)
       (when (member-if (lambda (type) (subtypep type nil))
 		     (cleavir-ir:required-types i))

--- a/Code/Cleavir/Type-inference/Transforms/packages.lisp
+++ b/Code/Cleavir/Type-inference/Transforms/packages.lisp
@@ -4,4 +4,5 @@
   (:use #:common-lisp #:cleavir-type-inference)
   (:export #:insert-type-checks)
   (:export #:thes->typeqs #:delete-the)
-  (:export #:prune-typeqs #:prune-the))
+  (:export #:prune-typeqs #:prune-the)
+  (:export #:mvcs->funcalls))

--- a/Code/Cleavir/Type-inference/bag-join.lisp
+++ b/Code/Cleavir/Type-inference/bag-join.lisp
@@ -17,5 +17,5 @@
 			       (cleavir-ir:lexical-location
 				(binary-join type-descriptor type))
 			       (cleavir-ir:values-location
-				(values-join type-descriptor type))))
+				(values-binary-join type-descriptor type))))
 		    finally (return result)))))

--- a/Code/Cleavir/Type-inference/bag-join.lisp
+++ b/Code/Cleavir/Type-inference/bag-join.lisp
@@ -5,12 +5,17 @@
     (return-from bag-join nil)) ; an empty bag.
   (loop for b in bags
 	do (assert (valid-bag-p b)))
-  (loop for (lexical . type-descriptor) in (first bags)
+  (loop for (location . type-descriptor) in (first bags)
 	collect
-	(cons lexical
+	(cons location
 	      (loop with result = type-descriptor
 		    for b in (rest bags)
-		    for r = (assoc lexical b :test #'eq)
+		    for r = (assoc location b :test #'eq)
 		    for type = (cdr r)
-		    do (setf result (binary-join type-descriptor type))
+		    do (setf result
+			     (etypecase location
+			       (cleavir-ir:lexical-location
+				(binary-join type-descriptor type))
+			       (cleavir-ir:values-location
+				(values-join type-descriptor type))))
 		    finally (return result)))))

--- a/Code/Cleavir/Type-inference/cleavir-type-inference.asd
+++ b/Code/Cleavir/Type-inference/cleavir-type-inference.asd
@@ -8,6 +8,7 @@
   ((:file "packages")
    (:file "dictionary")
    (:file "type-descriptor")
+   (:file "values-descriptor")
    (:file "sanity-checks")
    (:file "filter")
    (:file "bag-equal")

--- a/Code/Cleavir/Type-inference/packages.lisp
+++ b/Code/Cleavir/Type-inference/packages.lisp
@@ -6,6 +6,9 @@
 	   #:top-p #:bottom-p
 	   #:binary-join #:binary-meet #:difference
 	   #:join #:meet)
+  (:export #:approximate-values #:values-nth #:values-rest-p
+	   #:values-top-p #:values-bottom-p #:values-required-count
+	   #:values-meet #:values-join)
   (:export #:infer-types #:arc-bag
 	   #:instruction-input #:find-type)
   (:export #:type-missing

--- a/Code/Cleavir/Type-inference/packages.lisp
+++ b/Code/Cleavir/Type-inference/packages.lisp
@@ -7,10 +7,12 @@
 	   #:binary-join #:binary-meet #:difference
 	   #:join #:meet)
   (:export #:approximate-values #:values-nth #:values-rest-p
-	   #:values-top-p #:values-bottom-p #:values-required-count
+	   #:values-top-p #:values-bottom-p
+	   #:values-required #:values-required-count
 	   #:values-binary-meet #:values-binary-join
 	   #:values-meet #:values-join
-	   #:values-top #:values-bottom)
+	   #:values-top #:values-bottom
+	   #:values-descriptor->type)
   (:export #:infer-types #:arc-bag
 	   #:instruction-input #:find-type)
   (:export #:type-missing

--- a/Code/Cleavir/Type-inference/packages.lisp
+++ b/Code/Cleavir/Type-inference/packages.lisp
@@ -8,7 +8,9 @@
 	   #:join #:meet)
   (:export #:approximate-values #:values-nth #:values-rest-p
 	   #:values-top-p #:values-bottom-p #:values-required-count
-	   #:values-meet #:values-join)
+	   #:values-binary-meet #:values-binary-join
+	   #:values-meet #:values-join
+	   #:values-top #:values-bottom)
   (:export #:infer-types #:arc-bag
 	   #:instruction-input #:find-type)
   (:export #:type-missing

--- a/Code/Cleavir/Type-inference/sanity-checks.lisp
+++ b/Code/Cleavir/Type-inference/sanity-checks.lisp
@@ -1,11 +1,13 @@
 (cl:in-package #:cleavir-type-inference)
 
+;;; things we track.
+(deftype typed-location ()
+  '(or cleavir-ir:lexical-location cleavir-ir:values-location))
+
 (defun valid-bag-p (bag)
   (and (every (lambda (restriction)
 		(and (consp restriction)
-		     (typep (first restriction)
-			    'cleavir-ir:lexical-location)
-		     (symbolp (cdr restriction))))
+		     (typep (first restriction) 'typed-location)))
 	      bag)
        (= (length bag)
 	  (length (remove-duplicates bag :test #'eq :key #'first)))))

--- a/Code/Cleavir/Type-inference/transfer.lisp
+++ b/Code/Cleavir/Type-inference/transfer.lisp
@@ -1,7 +1,25 @@
 (cl:in-package #:cleavir-type-inference)
 
+;;; Called for effect. Update the inference information from the
+;;; instruction.
+(defgeneric process-instruction (instruction))
+
+;; default method. TODO: better dispatch here?
+(defmethod process-instruction (instruction)
+  (let ((input (instruction-input instruction *dictionary*)))
+    (ecase (length (cleavir-ir:successors instruction))
+      (0 nil)
+      (1 (one-successor-transfer instruction input))
+      (2 (two-successors-transfer instruction input)))))
+
+;;; These functions all take an instruction, and the bag of
+;;; descriptors in place as the input of that instruction.
+;;; That is, the bag is a bag-join of all incoming arcs' bags.
+
+;;; Returns one bag.
 (defgeneric one-successor-transfer (instruction input-bag))
 
+;;; Returns two bags, one for each branch.
 (defgeneric two-successors-transfer (instruction input-bag))
 
 (defmethod one-successor-transfer :around (instruction input-bag)

--- a/Code/Cleavir/Type-inference/transfer.lisp
+++ b/Code/Cleavir/Type-inference/transfer.lisp
@@ -83,14 +83,6 @@
 	  input-bag))
 
 (defmethod one-successor-transfer
-    ((instruction cleavir-ir:nop-instruction) input-bag)
-  input-bag)
-
-(defmethod one-successor-transfer
-    ((instruction cleavir-ir:use-instruction) input-bag)
-  input-bag)
-
-(defmethod one-successor-transfer
     ((instruction cleavir-ir:the-instruction) input-bag)
   (let* ((input (first (cleavir-ir:inputs instruction)))
 	 (input-type (find-type input input-bag))

--- a/Code/Cleavir/Type-inference/transfer.lisp
+++ b/Code/Cleavir/Type-inference/transfer.lisp
@@ -38,9 +38,7 @@
 	when (typep output 'cleavir-ir:lexical-location)
 	  do (setf result (update output t result))
 	when (typep output 'cleavir-ir:values-location)
-	  do (setf result (update output
-				  (approximate-values nil nil t)
-				  result))
+	  do (setf result (update output (values-top) result))
 	finally (return result)))
 
 (defmethod two-successors-transfer (instruction input-bag)
@@ -49,9 +47,7 @@
 	when (typep output 'cleavir-ir:lexical-location)
 	  do (setf result (update output t result))
 	when (typep output 'cleavir-ir:values-location)
-	  do (setf result (update output
-				  (approximate-values nil nil t)
-				  result))
+	  do (setf result (update output (values-top) result))
 	finally (return (values result result))))
 
 (defmethod two-successors-transfer :around (instruction input-bag)

--- a/Code/Cleavir/Type-inference/transfer.lisp
+++ b/Code/Cleavir/Type-inference/transfer.lisp
@@ -159,11 +159,8 @@
 		      input-bag)
 	for n from 0
 	for output in (cleavir-ir:outputs instruction)
-	for type = (find-type output input-bag)
-	for bag = input-bag
-	  then (update output
-		       (binary-meet type (values-nth vtype n))
-		       bag)
+	for bag = (update output (values-nth vtype n) input-bag)
+	  then (update output (values-nth vtype n) bag)
 	finally (return bag)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/Code/Cleavir/Type-inference/transfer.lisp
+++ b/Code/Cleavir/Type-inference/transfer.lisp
@@ -156,7 +156,7 @@
 	    (cleavir-ir:rest-type instruction))))
     (if (values-top-p descriptor)
 	input-bag ; don't bother
-	(update input (values-meet descriptor input-type)
+	(update input (values-binary-meet descriptor input-type)
 		input-bag))))
 
 (defmethod one-successor-transfer

--- a/Code/Cleavir/Type-inference/type-descriptor.lisp
+++ b/Code/Cleavir/Type-inference/type-descriptor.lisp
@@ -275,12 +275,6 @@
     ((simple-array bit) simple-array-bit)
     ((simple-array base-char) simple-array-base-char)))
 
-;;; TEMPORARY: All current type descriptors
-(deftype type-descriptor ()
-  '(member nil t fixnum null symbol cons
-    short-float single-float double-float long-float
-    simple-array-bit simple-array-base-char))
-
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;
 ;;; Function APPROXIMATE-TYPE.
@@ -327,10 +321,8 @@
 ;;; True if a descriptor is the top (T) or bottom (NIL) type, resp.
 
 (defun top-p (descriptor)
-  (check-type descriptor type-descriptor)
   (eq descriptor 't))
 (defun bottom-p (descriptor)
-  (check-type descriptor type-descriptor)
   (eq descriptor 'nil))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -341,14 +333,6 @@
 
 (defgeneric binary-meet (descriptor1 descriptor2))
 
-(defmethod binary-join :before (descriptor1 descriptor2)
-  (check-type descriptor1 type-descriptor)
-  (check-type descriptor2 type-descriptor))
-
-(defmethod binary-meet :before (descriptor1 descriptor2)
-  (check-type descriptor1 type-descriptor)
-  (check-type descriptor2 type-descriptor))
-
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;
 ;;; Function DIFFERENCE.
@@ -358,10 +342,6 @@
 ;;;  for typeq.
 
 (defgeneric difference (descriptor1 descriptor2))
-
-(defmethod difference :before (descriptor1 descriptor2)
-  (check-type descriptor1 type-descriptor)
-  (check-type descriptor2 type-descriptor))
 
 ;; we only actually need more methods if we include descriptors
 ;;  that are subtypes of one another.

--- a/Code/Cleavir/Type-inference/type-descriptor.lisp
+++ b/Code/Cleavir/Type-inference/type-descriptor.lisp
@@ -267,7 +267,6 @@
   '((nil nil)
     (fixnum fixnum)
     (null null)
-    (symbol symbol)
     (cons cons)
     (short-float short-float)
     (single-float single-float)
@@ -275,6 +274,12 @@
     (long-float long-float)
     ((simple-array bit) simple-array-bit)
     ((simple-array base-char) simple-array-base-char)))
+
+;;; TEMPORARY: All current type descriptors
+(deftype type-descriptor ()
+  '(member nil t fixnum null symbol cons
+    short-float single-float double-float long-float
+    simple-array-bit simple-array-base-char))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;
@@ -321,8 +326,12 @@
 ;;;
 ;;; True if a descriptor is the top (T) or bottom (NIL) type, resp.
 
-(defun top-p (descriptor) (eq descriptor 't))
-(defun bottom-p (descriptor) (eq descriptor 'nil))
+(defun top-p (descriptor)
+  (check-type descriptor type-descriptor)
+  (eq descriptor 't))
+(defun bottom-p (descriptor)
+  (check-type descriptor type-descriptor)
+  (eq descriptor 'nil))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;
@@ -331,6 +340,14 @@
 (defgeneric binary-join (descriptor1 descriptor2))
 
 (defgeneric binary-meet (descriptor1 descriptor2))
+
+(defmethod binary-join :before (descriptor1 descriptor2)
+  (check-type descriptor1 type-descriptor)
+  (check-type descriptor2 type-descriptor))
+
+(defmethod binary-meet :before (descriptor1 descriptor2)
+  (check-type descriptor1 type-descriptor)
+  (check-type descriptor2 type-descriptor))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;
@@ -341,6 +358,10 @@
 ;;;  for typeq.
 
 (defgeneric difference (descriptor1 descriptor2))
+
+(defmethod difference :before (descriptor1 descriptor2)
+  (check-type descriptor1 type-descriptor)
+  (check-type descriptor2 type-descriptor))
 
 ;; we only actually need more methods if we include descriptors
 ;;  that are subtypes of one another.

--- a/Code/Cleavir/Type-inference/type-descriptor.lisp
+++ b/Code/Cleavir/Type-inference/type-descriptor.lisp
@@ -249,8 +249,9 @@
 ;;;;    No reason to lose information.
 ;;;; 2) Dictionaries and bags only store descriptors.
 ;;;;    Call approximate- and canonicalize-type a lot.
-;;;; 3) All functions in this file return descriptors.
-;;;;    Other than approximate- and canonicalize-type,
+;;;; 3) All functions in this file return descriptors, not counting
+;;;;     type-equal, top-p, bottom-p.
+;;;;    Other than type-equal, approximate- and canonicalize-type,
 ;;;;     they only accept descriptors.
 
 ;;;; An alternate implementation option for this code is to lean
@@ -258,6 +259,22 @@
 ;;;;  is done, a coarser lattice can still be used by only storing
 ;;;;  canonicalized-types in the dictionary. But it means unboxed
 ;;;;  types are annoying (you could use satisfies, maybe?)
+
+;;; Map of CL types to type descriptors.
+;;; Checked left to right, so put more specific types first.
+;;; Could be fixed at compile time.
+(defparameter *cl-type->descriptors*
+  '((nil nil)
+    (fixnum fixnum)
+    (null null)
+    (symbol symbol)
+    (cons cons)
+    (short-float short-float)
+    (single-float single-float)
+    (double-float double-float)
+    (long-float long-float)
+    ((simple-array bit) simple-array-bit)
+    ((simple-array base-char) simple-array-base-char)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;
@@ -269,15 +286,11 @@
 ;;; FIXME: environment junk (typexpand).
 
 (defun approximate-type (type)
-  (cond ((subtypep type 'nil) 'nil)
-	((subtypep type 'fixnum) 'fixnum)
-	((subtypep type 'null) 'null)
-	((subtypep type 'cons) 'cons)
-	((subtypep type 'short-float) 'short-float)
-	((subtypep type 'single-float) 'single-float)
-	((subtypep type 'double-float) 'double-float)
-	((subtypep type 'long-float) 'long-float)
-	(t t)))
+  (loop for (ctype descriptor) in *cl-type->descriptors*
+	when (subtypep type ctype)
+	  do (return-from approximate-type descriptor))
+  ;; default
+  t)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;
@@ -296,18 +309,11 @@
 (defun type-equal (t1 t2)
   (and (subtypep t1 t2) (subtypep t2 t1)))
 
-;; FIXME: duplicates approximate-type too much. Could have a
-;;  macro-time map from types to descriptors.
 (defun canonicalize-type (type)
-  (cond ((subtypep type 'nil) (values 'nil t))
-	((type-equal type 'fixnum) (values 'fixnum t))
-	((type-equal type 'null) (values 'null t))
-	((type-equal type 'cons) (values 'cons t))
-	((type-equal type 'short-float) (values 'short-float t))
-	((type-equal type 'single-float) (values 'single-float t))
-	((type-equal type 'double-float) (values 'double-float t))
-	((type-equal type 'long-float) (values 'long-float t))
-	(t (values nil nil))))
+  (loop for (ctype descriptor) in *cl-type->descriptors*
+	when (type-equal type ctype)
+	  do (return-from canonicalize-type descriptor))
+  t)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;
@@ -400,7 +406,8 @@
 			append (loop for d2 in rest
 				     collect `(disjoin ,d1 ,d2))))))
   (pairwise fixnum null cons
-	    short-float single-float double-float long-float))
+	    short-float single-float double-float long-float
+	    simple-array-bit simple-array-base-char))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;

--- a/Code/Cleavir/Type-inference/type-inference.lisp
+++ b/Code/Cleavir/Type-inference/type-inference.lisp
@@ -23,10 +23,7 @@
 				 (arc-bag predecessor instruction
 					  result))
 		      when (typep var 'cleavir-ir:values-location)
-			do (push (cons
-				  var
-				  ;; top type
-				  (approximate-values nil nil t))
+			do (push (cons var (values-top))
 				 (arc-bag predecessor instruction
 					  result)))))
      initial-instruction)

--- a/Code/Cleavir/Type-inference/type-inference.lisp
+++ b/Code/Cleavir/Type-inference/type-inference.lisp
@@ -32,13 +32,6 @@
      initial-instruction)
     result))
 
-(defun process-instruction (instruction)
-  (let ((input (instruction-input instruction *dictionary*)))
-    (ecase (length (cleavir-ir:successors instruction))
-      (0 nil)
-      (1 (one-successor-transfer instruction input))
-      (2 (two-successors-transfer instruction input)))))
-
 (defun infer-types (initial-instruction)
   (let ((*work-list* (compute-initial-work-list initial-instruction))
 	(*dictionary* (compute-initial-dictionary initial-instruction)))

--- a/Code/Cleavir/Type-inference/type-inference.lisp
+++ b/Code/Cleavir/Type-inference/type-inference.lisp
@@ -35,3 +35,33 @@
     (loop until (null *work-list*)
 	  do (process-instruction (pop *work-list*)))
     *dictionary*))
+
+(defun inferred-enter-types (initial-instruction types)
+  ;; given how few enter instructions are usually around,
+  ;; using a hash table is a bit overkill.
+  (let ((result (make-hash-table :test 'eq)))
+    ;; first put all the enter instructions in the result.
+    ;; default value is bottom, which will remain if it never
+    ;; returns normally.
+    (cleavir-ir:map-instructions-arbitrary-order
+     (lambda (instruction)
+       (when (typep instruction 'cleavir-ir:enter-instruction)
+	 (setf (gethash instruction result) (values-bottom))))
+     initial-instruction)
+    ;; now find all return instructions. join the values at each
+    ;; with whatever is already known.
+    (cleavir-ir:map-instructions-with-owner
+     (lambda (instruction owner)
+       (when (typep instruction 'cleavir-ir:return-instruction)
+	 (setf (gethash owner result)
+	       (values-binary-join
+		(gethash owner result)
+		(find-type (first (cleavir-ir:inputs instruction))
+			   (instruction-input instruction types))))))
+     initial-instruction)
+    ;; finally, make it a bit more presentable.
+    (maphash (lambda (k v)
+	       (setf (gethash k result)
+		     `(function * ,(values-descriptor->type v))))
+	     result)
+    result))

--- a/Code/Cleavir/Type-inference/type-inference.lisp
+++ b/Code/Cleavir/Type-inference/type-inference.lisp
@@ -21,6 +21,13 @@
 		      when (typep var 'cleavir-ir:lexical-location)
 			do (push (cons var t)
 				 (arc-bag predecessor instruction
+					  result))
+		      when (typep var 'cleavir-ir:values-location)
+			do (push (cons
+				  var
+				  ;; top type
+				  (approximate-values nil nil t))
+				 (arc-bag predecessor instruction
 					  result)))))
      initial-instruction)
     result))

--- a/Code/Cleavir/Type-inference/values-descriptor.lisp
+++ b/Code/Cleavir/Type-inference/values-descriptor.lisp
@@ -1,0 +1,66 @@
+(in-package #:cleavir-type-inference)
+
+;;; Values descriptors are lists.
+;;; The first element is whether the number of values is fixed.
+;;; The remaining elements are the descriptors of the required
+;;;  values, in order.
+;;; (values a b c &rest t) => (T A B C)
+;;; (values a b c &rest nil) => (NIL A B C)
+;;; (values a b &optional c &rest nil) => (T A B)
+;;; (values a b &optional c &rest t) => (T A B)
+;;; (values a &rest b) => (T A)
+;;; In other words, we don't care about &optional or weird &rest.
+
+(defun values-nth (values-descriptor n)
+  (if (>= n (values-required-count values-descriptor))
+      (values-rest-p values-descriptor)
+      (nth n (rest values-descriptor))))
+
+(defun values-rest-p (values-descriptor)
+  (first values-descriptor))
+
+;; does the type not have any information?
+(defun values-top-p (values-descriptor)
+  (and (first values-descriptor) ; rest-p
+       (every #'top-p (rest values-descriptor))))
+
+(defun values-bottom-p (values-descriptor)
+  (some #'bottom-p (rest values-descriptor)))
+
+(defun values-required-count (values-descriptor)
+  (length (rest values-descriptor)))
+
+(defun approximate-values (required optional rest)
+  (cons (if (or optional (not (bottom-p (approximate-type rest))))
+	    t
+	    nil)
+	(mapcar #'approximate-type required)))
+
+(defun values-meet (v1 v2)
+  (let ((bottom-values '(t nil)) ; (values nil)
+	(nv1 (values-required-count v1))
+	(nv2 (values-required-count v2))
+	max)
+    (cond ((< nv1 nv2)
+	   (if (values-rest-p v1)
+	       (setf max nv2)
+	       (return-from values-meet bottom-values)))
+	  ((< nv2 nv1)
+	   (if (values-rest-p v2)
+	       (setf max nv1)
+	       (return-from values-meet bottom-values)))
+	  (t ; equal
+	   (setf max nv1)))
+    (cons (and (values-rest-p v1) (values-rest-p v2))
+	  (loop for n from 0 below max
+		collect (binary-meet (values-nth v1 n)
+				     (values-nth v2 n))))))
+
+(defun values-join (v1 v2)
+  (let* ((nv1 (values-required-count v1))
+	 (nv2 (values-required-count v2))
+	 (min (min nv1 nv2)))
+    (cons (or (/= nv1 nv2) (values-rest-p v1) (values-rest-p v2))
+	  (loop for n from 0 below min
+		collect (binary-join (values-nth v1 n)
+				     (values-nth v2 n))))))


### PR DESCRIPTION
Should all be non-breaking. Most of these changes are in the depths of type inference: reorganizations, but more importantly added tracking of values types. This preserves type information through M->F and F->M and allows extraction of it near return instructions; this should be helpful later on for inter-function optimization.

There are two new transforms. One doesn't use inference and just find explicit NIL returns and changes them to funcall-no-return to clean up the instruction graph. The other turns multiple-value-call where the numbers of values are known into M->F and funcall. Ideally this should help avoid unknown-values returns lower down.

Higher up I added a primop and AST, VALUES, for inlining calls to cl:values. Basically

    (define-compiler-macro values (&rest args) `(cleavir-primop:values ,@args))

and explicit calls will compile into an F->M instead of a funcall. Again, helps inference.