### PR TITLE
Ast to hir errors

### DIFF
--- a/Code/Cleavir/AST-to-HIR/cleavir-ast-to-hir.asd
+++ b/Code/Cleavir/AST-to-HIR/cleavir-ast-to-hir.asd
@@ -7,11 +7,14 @@
 ;;;; compilation of the entire AST.
 
 (defsystem :cleavir-ast-to-hir
-  :depends-on (:cleavir-ast :cleavir-hir :cleavir-primop)
+  :depends-on (:acclimation
+	       :cleavir-ast :cleavir-hir :cleavir-primop)
   :serial t
   :components
   ((:file "packages")
    (:file "context")
+   (:file "conditions")
+   (:file "condition-reporters-english")
    (:file "compile-general-purpose-asts")
    (:file "compile-fixnum-related-asts")
    (:file "compile-float-related-asts")

--- a/Code/Cleavir/AST-to-HIR/compile-array-related-asts.lisp
+++ b/Code/Cleavir/AST-to-HIR/compile-array-related-asts.lisp
@@ -5,7 +5,6 @@
 ;;; Compile a SIMPLE-T-AREF-AST
 
 (defmethod compile-ast ((ast cleavir-ast:simple-t-aref-ast) context)
-  (check-context-for-one-value-ast context)
   (let ((temp1 (make-temp))
 	(temp2 (make-temp)))
     (compile-ast
@@ -27,7 +26,6 @@
 ;;; Compile a SIMPLE-T-ASET-AST
 
 (defmethod compile-ast ((ast cleavir-ast:simple-t-aset-ast) context)
-  (check-context-for-no-value-ast context)
   (let ((temp1 (make-temp))
 	(temp2 (make-temp))
 	(temp3 (make-temp)))
@@ -56,7 +54,6 @@
 ;;; Compile a NON-SIMPLE-T-AREF-AST
 
 (defmethod compile-ast ((ast cleavir-ast:non-simple-t-aref-ast) context)
-  (check-context-for-one-value-ast context)
   (let ((temp1 (make-temp))
 	(temp2 (make-temp)))
     (compile-ast
@@ -78,7 +75,6 @@
 ;;; Compile a NON-SIMPLE-T-ASET-AST
 
 (defmethod compile-ast ((ast cleavir-ast:non-simple-t-aset-ast) context)
-  (check-context-for-no-value-ast context)
   (let ((temp1 (make-temp))
 	(temp2 (make-temp))
 	(temp3 (make-temp)))
@@ -109,7 +105,6 @@
 (defmacro compile-specialized-aref-ast
     (ast-class aref-instruction-class box-instruction-class)
   `(defmethod compile-ast ((ast ,ast-class) context)
-     (check-context-for-one-value-ast context)
      (let ((temp1 (make-temp))
 	   (temp2 (make-temp))
 	   (temp3 (make-temp)))
@@ -175,7 +170,6 @@
 (defmacro compile-specialized-aset-ast
     (ast-class aset-instruction-class unbox-instruction-class)
   `(defmethod compile-ast ((ast ,ast-class) context)
-     (check-context-for-no-value-ast context)
      (let ((temp1 (make-temp))
 	   (temp2 (make-temp))
 	   (temp3 (make-temp))

--- a/Code/Cleavir/AST-to-HIR/compile-cons-related-asts.lisp
+++ b/Code/Cleavir/AST-to-HIR/compile-cons-related-asts.lisp
@@ -5,7 +5,6 @@
 ;;; Compile a CAR-AST
 
 (defmethod compile-ast ((ast cleavir-ast:car-ast) context)
-  (check-context-for-one-value-ast context)
   (let ((temp (make-temp)))
     (compile-ast
      (cleavir-ast:cons-ast ast)
@@ -21,7 +20,6 @@
 ;;; Compile a CDR-AST
 
 (defmethod compile-ast ((ast cleavir-ast:cdr-ast) context)
-  (check-context-for-one-value-ast context)
   (let ((temp (make-temp)))
     (compile-ast
      (cleavir-ast:cons-ast ast)
@@ -37,7 +35,6 @@
 ;;; Compile a RPLACA-AST
 
 (defmethod compile-ast ((ast cleavir-ast:rplaca-ast) context)
-  (check-context-for-no-value-ast context)
   (let ((temp1 (make-temp))
 	(temp2 (make-temp)))
     (compile-ast
@@ -59,7 +56,6 @@
 ;;; Compile a RPLACD-AST
 
 (defmethod compile-ast ((ast cleavir-ast:rplacd-ast) context)
-  (check-context-for-no-value-ast context)
   (let ((temp1 (make-temp))
 	(temp2 (make-temp)))
     (compile-ast

--- a/Code/Cleavir/AST-to-HIR/compile-fixnum-related-asts.lisp
+++ b/Code/Cleavir/AST-to-HIR/compile-fixnum-related-asts.lisp
@@ -8,8 +8,7 @@
   (with-accessors ((results results)
 		   (successors successors))
       context
-    (unless (= (length successors) 2)
-      (error "Invalid context for FIXNUM-ADD-AST."))
+    (assert-context ast context 1 2)
     (let ((temp1 (make-temp))
 	  (temp2 (make-temp))
 	  (result (find-or-create-location (cleavir-ast:variable-ast ast))))
@@ -34,8 +33,7 @@
   (with-accessors ((results results)
 		   (successors successors))
       context
-    (unless (= (length successors) 2)
-      (error "Invalid context for FIXNUM-SUB-AST."))
+    (assert-context ast context 1 2)
     (let ((temp1 (make-temp))
 	  (temp2 (make-temp))
 	  (result (find-or-create-location (cleavir-ast:variable-ast ast))))
@@ -60,9 +58,7 @@
   (with-accessors ((results results)
 		   (successors successors))
       context
-    (unless (and (null results)
-		 (= (length successors) 2))
-      (error "Invalid context for FIXNUM-LESS-AST."))
+    (assert-context ast context 0 2)
     (let ((temp1 (make-temp))
 	  (temp2 (make-temp)))
       (compile-ast
@@ -86,9 +82,7 @@
   (with-accessors ((results results)
 		   (successors successors))
       context
-    (unless (and (null results)
-		 (= (length successors) 2))
-      (error "Invalid context for FIXNUM-NOT-GREATER-AST."))
+    (assert-context ast context 0 2)
     (let ((temp1 (make-temp))
 	  (temp2 (make-temp)))
       (compile-ast
@@ -112,9 +106,7 @@
   (with-accessors ((results results)
 		   (successors successors))
       context
-    (unless (and (null results)
-		 (= (length successors) 2))
-      (error "Invalid context for FIXNUM-GREATER-AST."))
+    (assert-context ast context 0 2)
     (let ((temp1 (make-temp))
 	  (temp2 (make-temp)))
       (compile-ast
@@ -138,9 +130,7 @@
   (with-accessors ((results results)
 		   (successors successors))
       context
-    (unless (and (null results)
-		 (= (length successors) 2))
-      (error "Invalid context for FIXNUM-NOT-LESS-AST."))
+    (assert-context ast context 0 2)
     (let ((temp1 (make-temp))
 	  (temp2 (make-temp)))
       (compile-ast
@@ -164,9 +154,7 @@
   (with-accessors ((results results)
 		   (successors successors))
       context
-    (unless (and (null results)
-		 (= (length successors) 2))
-      (error "Invalid context for FIXNUM-EQUAL-AST."))
+    (assert-context ast context 0 2)
     (let ((temp1 (make-temp))
 	  (temp2 (make-temp)))
       (compile-ast

--- a/Code/Cleavir/AST-to-HIR/compile-float-related-asts.lisp
+++ b/Code/Cleavir/AST-to-HIR/compile-float-related-asts.lisp
@@ -28,7 +28,6 @@
 (defmacro compile-float-arithmetic-ast
     (ast-class instruction-class unbox-instruction-class box-instruction-class)
   `(defmethod compile-ast ((ast ,ast-class) context)
-     (check-context-for-one-value-ast context)
      (let* ((arguments (cleavir-ast:children ast))
 	    (temps (make-temps arguments))
 	    (temp (cleavir-ir:new-temporary))
@@ -192,6 +191,7 @@
 (defmacro compile-float-comparison-ast
     (ast-class instruction-class unbox-instruction-class input-transformer)
   `(defmethod compile-ast ((ast ,ast-class) context)
+     (assert-context ast context 0 2)
      (check-context-for-boolean-ast context)
      (let* ((arguments (cleavir-ast:children ast))
 	    (temps (make-temps arguments)))

--- a/Code/Cleavir/AST-to-HIR/compile-standard-object-related-asts.lisp
+++ b/Code/Cleavir/AST-to-HIR/compile-standard-object-related-asts.lisp
@@ -5,7 +5,6 @@
 ;;; Compile a SLOT-READ-AST
 
 (defmethod compile-ast ((ast cleavir-ast:slot-read-ast) context)
-  (check-context-for-one-value-ast context)
   (let ((temp1 (make-temp))
 	(temp2 (make-temp)))
     (compile-ast
@@ -27,7 +26,6 @@
 ;;; Compile a SLOT-WRITE-AST
 
 (defmethod compile-ast ((ast cleavir-ast:slot-write-ast) context)
-  (check-context-for-no-value-ast context)
   (let ((temp1 (make-temp))
 	(temp2 (make-temp))
 	(temp3 (make-temp)))

--- a/Code/Cleavir/AST-to-HIR/condition-reporters-english.lisp
+++ b/Code/Cleavir/AST-to-HIR/condition-reporters-english.lisp
@@ -2,15 +2,16 @@
 
 (defmethod acclimation:report-condition
     ((condition miscontext) stream (language acclimation:english))
-  ;; signaling an error in an error report may not be good.
-  (assert (or (ast-results condition) (ast-successors condition)))
-  (format stream
-	  "Error during AST-TO-HIR:~@
-           Found ~a (which has ~@[~d results ~]~@[~d successors~]) in context where ~@[~d results ~]~@[~d successors ~] were expected.
-           This is probably caused by a bug in GENERATE-AST."
-	  (ast condition)
-	  (ast-results condition)
-	  (ast-successors condition)
-	  (if (ast-results condition) (results context) nil)
-	  (if (ast-successors condition)
-	      (successors context) nil)))
+  (with-accessors ((ast ast) (results ast-results)
+		   (successors ast-successors)
+		   (context miscontext-context))
+      condition
+    ;; signaling an error in an error report may not be good.
+    (assert (or results successors))
+    (format stream
+	    "Error during AST-TO-HIR:~@
+             Found ~a (which has ~@[~d results ~]~@[~d successors~]) in context where ~@[~d results ~]~@[~d successors ~]were expected.~@
+             This is probably caused by a bug in GENERATE-AST."
+	    ast results successors
+	    (if results (results context) nil)
+	    (if successors (length (successors context)) nil))))

--- a/Code/Cleavir/AST-to-HIR/condition-reporters-english.lisp
+++ b/Code/Cleavir/AST-to-HIR/condition-reporters-english.lisp
@@ -1,0 +1,16 @@
+(cl:in-package #:cleavir-ast-to-hir)
+
+(defmethod acclimation:report-condition
+    ((condition miscontext) stream (language acclimation:english))
+  ;; signaling an error in an error report may not be good.
+  (assert (or (ast-results condition) (ast-successors condition)))
+  (format stream
+	  "Error during AST-TO-HIR:~@
+           Found ~a (which has ~@[~d results ~]~@[~d successors~]) in context where ~@[~d results ~]~@[~d successors ~] were expected.
+           This is probably caused by a bug in GENERATE-AST."
+	  (ast condition)
+	  (ast-results condition)
+	  (ast-successors condition)
+	  (if (ast-results condition) (results context) nil)
+	  (if (ast-successors condition)
+	      (successors context) nil)))

--- a/Code/Cleavir/AST-to-HIR/conditions.lisp
+++ b/Code/Cleavir/AST-to-HIR/conditions.lisp
@@ -11,9 +11,11 @@
    (%ast-successors :initarg :ast-successors :reader ast-successors)))
 
 (defun assert-context (ast context ast-results ast-successors)
-  (when (or (and ast-results (/= ast-results (results context)))
+  (when (or (and ast-results
+		 (/= ast-results (length (results context))))
 	    (and ast-successors
-		 (= ast-successors (length (successors context)))))
+		 (/= ast-successors
+		     (length (successors context)))))
     (error 'miscontext :ast ast :context context
 		       :ast-results ast-results
 		       :ast-successors ast-successors)))

--- a/Code/Cleavir/AST-to-HIR/conditions.lisp
+++ b/Code/Cleavir/AST-to-HIR/conditions.lisp
@@ -13,7 +13,7 @@
 (defun assert-context (ast context ast-results ast-successors)
   (when (or (and ast-results (/= ast-results (results context)))
 	    (and ast-successors
-		 (= ast-successors (successors context))))
+		 (= ast-successors (length (successors context)))))
     (error 'miscontext :ast ast :context context
 		       :ast-results ast-results
 		       :ast-successors ast-successors)))

--- a/Code/Cleavir/AST-to-HIR/conditions.lisp
+++ b/Code/Cleavir/AST-to-HIR/conditions.lisp
@@ -1,0 +1,17 @@
+;;; An AST appears in a context inappropriate for it.
+;;; This is a fatal compiler error.
+(define-condition miscontext (error acclimation:condition)
+  ((%ast :initarg :ast :reader ast)
+   (%context :initarg :context :reader miscontext-context)
+   ;; The AST needs this many results and this many successors.
+   ;; NIL is don't-care
+   (%ast-results :initarg :ast-results :reader ast-results)
+   (%ast-successors :initarg :ast-successors :reader ast-successors)))
+
+(defun assert-context (ast context ast-results ast-successors)
+  (when (or (and ast-results (/= ast-results (results context)))
+	    (and ast-successors
+		 (= ast-successors (successors context))))
+    (error 'miscontext :ast ast :context context
+		       :ast-results ast-results
+		       :ast-successors ast-successors)))

--- a/Code/Cleavir/AST-to-HIR/conditions.lisp
+++ b/Code/Cleavir/AST-to-HIR/conditions.lisp
@@ -1,3 +1,5 @@
+(in-package #:cleavir-ast-to-hir)
+
 ;;; An AST appears in a context inappropriate for it.
 ;;; This is a fatal compiler error.
 (define-condition miscontext (error acclimation:condition)


### PR DESCRIPTION
clean up ast-to-hir a bit by having it signal specific conditions and so on.