### PR TITLE
Inline closures

### DIFF
--- a/Code/Cleavir/AST-transformations/clone.lisp
+++ b/Code/Cleavir/AST-transformations/clone.lisp
@@ -12,8 +12,8 @@
 ;;; initialized by :INITFORM.
 
 ;;; "every" must exclude lexical ASTs that are not defined (by a
-;;; function or setq) locally, because they are outer closed-over
-;;; variables.
+;;; function, setq, etc.) locally, because they are outer
+;;; closed-over variables.
 
 ;;; return a list, in arbitrary order, of all the lexical ASTs
 ;;; defined by a given lambda list (from a function-ast).
@@ -45,6 +45,10 @@
             (mapc #'register-ast
                   (lambda-list-lexicals
                    (cleavir-ast:lambda-list node)))
+            (register-ast node))
+           ((or cleavir-ast:fixnum-add-ast
+                cleavir-ast:fixnum-sub-ast)
+            (register-ast (cleavir-ast:variable-ast node))
             (register-ast node))
            ;; should be registered by the above if local.
            (cleavir-ast:lexical-ast)

--- a/Code/Cleavir/AST-transformations/clone.lisp
+++ b/Code/Cleavir/AST-transformations/clone.lisp
@@ -10,14 +10,47 @@
 ;;; node.  No initialization arguments are passed to MAKE-INSTANCE, so
 ;;; the cloned node is uninitialized except for slots that are
 ;;; initialized by :INITFORM.
+
+;;; "every" must exclude lexical ASTs that are not defined (by a
+;;; function or setq) locally, because they are outer closed-over
+;;; variables.
+
+;;; return a list, in arbitrary order, of all the lexical ASTs
+;;; defined by a given lambda list (from a function-ast).
+(defun lambda-list-lexicals (lambda-list)
+  (loop with result = nil
+        for item in lambda-list
+        do (cond ((member item lambda-list-keywords))
+                 ((atom item) (push item result))
+                 ((= (length item) 3) ; &key
+                  (push (second item) result)
+                  (push (third item) result))
+                 (t ; &optional, we assume
+                  (push (first item) result)
+                  (push (second item) result)))
+        finally (return result)))
+
 (defun clone-create-dictionary (ast)
   (let ((dictionary (make-hash-table :test #'eq)))
-    (cleavir-ast:map-ast-depth-first-preorder
-     (lambda (node)
-       (setf (gethash node dictionary)
-	     (make-instance (class-of node))))
-     ast)
-    dictionary))
+    (flet ((register-ast (node)
+             (setf (gethash node dictionary)
+                   (make-instance (class-of node)))))
+      (cleavir-ast:map-ast-depth-first-preorder
+       (lambda (node)
+         (typecase node
+           (cleavir-ast:setq-ast
+            (register-ast (cleavir-ast:lhs-ast node))
+            (register-ast node))
+           (cleavir-ast:function-ast
+            (mapc #'register-ast
+                  (lambda-list-lexicals
+                   (cleavir-ast:lambda-list node)))
+            (register-ast node))
+           ;; should be registered by the above if local.
+           (cleavir-ast:lexical-ast)
+           (t (register-ast node))))
+       ast)
+      dictionary)))
 
 ;;; This generic function is used to obtain some substructure
 ;;; (typically a slot) for the new AST, given the corresponding


### PR DESCRIPTION
This fixes a bug in compiling e.g.

(lambda (x)
  (flet ((foo () x))
    (declare (inline foo))
    (foo)))

without this patch, the AST will duplicate the lexical variable in the inline expansion, disconnecting it from its binding. This has the practical effect of filling x with garbage data in the final compiled code.

I don't particularly like this solution, since it relies on knowing all ASTs that define variables. But I think it's just about the only way to do it within how ASTs work.