### PR TITLE
Change how cells and specials work

### DIFF
--- a/Code/Cleavir/Generate-AST/check-special-form-syntax.lisp
+++ b/Code/Cleavir/Generate-AST/check-special-form-syntax.lisp
@@ -306,6 +306,7 @@
 (define-simple-check cleavir-primop:aref 5)
 (define-simple-check cleavir-primop:aset 6)
 (define-simple-check cleavir-primop:short-float-add 2)
+(define-simple-check cleavir-primop:ast 1)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;

--- a/Code/Cleavir/Generate-AST/convert-primop.lisp
+++ b/Code/Cleavir/Generate-AST/convert-primop.lisp
@@ -526,3 +526,15 @@
 		     (lambda (form) (convert form env system))
 		     arguments)
      :origin origin)))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;
+;;; Converting CLEAVIR-PRIMOP:AST.
+;;;
+;;; This allows ASTs produced by other means to be inserted into
+;;; code which is then converted again.
+
+(defmethod convert-special
+    ((symbol (eql 'cleavir-primop:ast)) form env system)
+  (declare (ignore env system))
+  (db origin (ast) (rest form) ast))

--- a/Code/Cleavir/HIR-transformations/compute-ownership.lisp
+++ b/Code/Cleavir/HIR-transformations/compute-ownership.lisp
@@ -54,7 +54,7 @@
 ;;; has been attributed an owner already, in which case we do nothing.
 (defun compute-location-owners (initial-instruction)
   (let ((result (make-hash-table :test #'eq)))
-    (cleavir-ir:map-instructions-by/with-owner 
+    (cleavir-ir:map-instructions-by/with-owner
      (lambda (instruction owner)
        (loop for datum in (append (cleavir-ir:inputs instruction)
 				  (cleavir-ir:outputs instruction))
@@ -63,3 +63,27 @@
      initial-instruction)
     result))
 
+;;; Return a hash table from outputs to the first instruction having
+;;; that output. This is where the create-cell instruction goes.
+;;; This of course assumes that such an instruction exists. It
+;;; should for CL code, as far as Bike knows, but you could do
+;;; (cleavir-primop:let-uninitialized (x)
+;;;   (if (condition) (setf x y) (setf x z)))
+;;; in which case exactly one of the two branches would be the
+;;; first definer in any control path. In this situation this
+;;; function will return only one instruction and functions relying
+;;; on it will probably fail mysteriously.
+;;; So don't do that.
+;;; (cleavir-primop:let-uninitialized (x)
+;;;   ((lambda () (setf x y)))
+;;;   x)
+;;; would also be problematic.
+(defun compute-location-definers (initial-instruction)
+  (let ((result (make-hash-table :test #'eq)))
+    (cleavir-ir:map-instructions
+     (lambda (instruction)
+       (loop for datum in (cleavir-ir:outputs instruction)
+             when (null (gethash datum result))
+               do (setf (gethash datum result) instruction)))
+     initial-instruction)
+    result))

--- a/Code/Cleavir/Primop/packages.lisp
+++ b/Code/Cleavir/Primop/packages.lisp
@@ -68,4 +68,5 @@
    #:call-with-variable-bound
    #:let-uninitialized
    #:funcall
-   #:values))
+   #:values
+   #:ast))


### PR DESCRIPTION
Two changes. One is to fix the (loop for i below 5 collect (let ((x i)) (lambda () x))) thing I mentioned a while ago. The other lets CLEAVIR-PRIMOP:CALL-WITH-VARIABLE-BOUND be something other than a function and adds the primop for literal ASTs we discussed before. Commit messages have more info.