### PR TITLE
Check the *READ-DEFAULT-FLOAT-FORMAT* variable in the simple reader.

### DIFF
--- a/Code/Cleavir/HIR-transformations/Partial-inlining/inline-one-instruction.lisp
+++ b/Code/Cleavir/HIR-transformations/Partial-inlining/inline-one-instruction.lisp
@@ -43,3 +43,10 @@
                     (list new)))
              (add-to-mapping mapping output new)
              new))))
+    
+(defun translate-outputs (outputs call-instruction enter-instruction mapping)
+  (loop for output in outputs
+        collect (translate-output output
+                                  call-instruction
+                                  enter-instruction
+                                  mapping)))

--- a/Code/Cleavir/HIR-transformations/Partial-inlining/inline-one-instruction.lisp
+++ b/Code/Cleavir/HIR-transformations/Partial-inlining/inline-one-instruction.lisp
@@ -15,14 +15,9 @@
   (eq (gethash location *location-ownerships*)
       *original-enter-instruction*))
 
-(defun translate-location (location mapping)
-  (let ((new (find-in-mapping mapping location)))
-    (when (and (null new)
-               (local-location-p location))
-      (setf new (cleavir-ir:new-temporary))
-      (add-to-mapping mapping location new))
-    new))
-
-(defun translate-loations (locations mapping)
-  (loop for location in locations
-        collect (translate-location location mapping)))
+(defun translate-inputs (inputs mapping)
+  ;; An input is either already in the mapping, or else it is
+  ;; is a location that is owned by some ancestor function.
+  (loop for input in inputs
+        for new = (find-in-mapping mapping input)
+        collect (if (null new) input new)))

--- a/Code/Cleavir/HIR-transformations/Partial-inlining/inline-one-instruction.lisp
+++ b/Code/Cleavir/HIR-transformations/Partial-inlining/inline-one-instruction.lisp
@@ -50,3 +50,29 @@
                                   call-instruction
                                   enter-instruction
                                   mapping)))
+
+(defmethod inline-one-instruction
+    (enclose-instruction
+     call-instruction
+     enter-instruction
+     (successor-instruction cleavir-ir:one-successor-mixin)
+     mapping)
+  (let* ((inputs (cleavir-ir:inputs successor-instruction))
+         (new-inputs (translate-inputs inputs mapping))
+         (outputs (cleavir-ir:outputs successor-instruction))
+         (new-outputs (translate-outputs outputs
+                                         call-instruction
+                                         enter-instruction
+                                         mapping))
+         (new-instruction (make-instance (class-of successor-instruction)
+                            :inputs new-inputs
+                            :outputs new-outputs)))
+    (add-to-mapping mapping successor-instruction new-instruction)
+    (cleavir-ir:insert-instruction-before new-instruction call-instruction)
+    (setf (cleavir-ir:successors enter-instruction)
+          (list (cleavir-ir:successors successor-instruction)))
+    (list (make-instance 'worklist-item
+            :enclose-instruction enclose-instruction
+            :call-instruction call-instruction
+            :enter-instruction enter-instruction
+            :mapping mapping))))

--- a/Code/Reader/Simple/additional-conditions.lisp
+++ b/Code/Reader/Simple/additional-conditions.lisp
@@ -89,6 +89,9 @@
 (define-condition invalid-radix (reader-error)
   ((%radix :initarg :radix :reader radix)))
 
+(define-condition invalid-default-float-format (reader-error)
+  ((%float-format :initarg :float-format :reader float-format)))
+
 (define-condition too-many-elements (reader-error)
   ((%exptected-number :initarg :expected-number :reader expected-number)
    (%number-found :initarg :number-found :reader number-found)))

--- a/Code/Reader/Simple/packages.lisp
+++ b/Code/Reader/Simple/packages.lisp
@@ -65,6 +65,7 @@
    #:symbol-can-have-at-most-two-package-markers
    #:unknown-character-name
    #:digit-expected
+   #:invalid-default-float-format
    ;; Names of macros related to backquote.
    ;; We export them so that the pretty printer
    ;; can use them properly.


### PR DESCRIPTION
This checks that the variable holds a suitable value before trying to use it. If the variable is not set to one of the types allowed by the spec, we check if it is a subtype of `float` (as implementation-specific behaviour is allowed) and if it is not then we signal an error.