### PR TITLE
Insert missing DECLARE into list of declarations

### DIFF
--- a/Code/Cleavir/CST-to-AST/convert-let-and-letstar.lisp
+++ b/Code/Cleavir/CST-to-AST/convert-let-and-letstar.lisp
@@ -100,8 +100,12 @@
                                (cons (cst:cst-from-expression 'locally)
                                      (if (null remaining-dspecs)
                                          body-csts
-                                         (cons remaining-dspecs-cst
-                                               body-csts))))
+                                         (cons
+                                          (make-instance 'cst:cons-cst
+                                                         :first (cst:cst-from-expression 'declare)
+                                                         :rest remaining-dspecs-cst
+                                                         :raw (cl:cons 'declare (cst:raw remaining-dspecs-cst)))
+                                          body-csts))))
                 for binding-cst in (reverse binding-csts)
                 for declaration-cst in (reverse item-specific-dspecs)
                 do (setf result


### PR DESCRIPTION
This comes up in LET* convertion to LET.
It converts declarations into a LOCALLY special operator that is missing
a DECLARE symbol.