### PR TITLE
Adapt CST-to-AST to SEPARATE-{ORDINARY,FUNCTION}-BODY changes

### DIFF
--- a/Code/Cleavir/CST-to-AST/convert-code.lisp
+++ b/Code/Cleavir/CST-to-AST/convert-code.lisp
@@ -462,7 +462,7 @@
       (error 'malformed-lambda-list
              :expr (cst:raw lambda-list-cst)
              :origin (cst:source lambda-list-cst)))
-    (multiple-value-bind (declaration-csts documentation form-csts)
+    (multiple-value-bind (declaration-csts documentation forms-cst)
         (cst:separate-function-body body-cst)
       ;; FIXME: Handle documentation
       (declare (ignore documentation))
@@ -481,7 +481,7 @@
               (process-parameter-groups
                (cst:children parsed-lambda-list)
                idspecs
-               (make-body rdspecs form-csts block-name-cst)
+               (make-body rdspecs (cst:listify forms-cst) block-name-cst)
                env
                system)
             (cleavir-ast:make-function-ast ast lexical-lambda-list :origin origin)))))))

--- a/Code/Cleavir/CST-to-AST/convert-let-and-letstar.lisp
+++ b/Code/Cleavir/CST-to-AST/convert-let-and-letstar.lisp
@@ -82,7 +82,7 @@
   (cst:db origin (let*-cst bindings-cst . body-forms-cst) cst
     (declare (ignore let*-cst))
     (check-bindings bindings-cst)
-    (multiple-value-bind (declaration-csts body-csts)
+    (multiple-value-bind (declaration-csts forms-cst)
         (cst:separate-ordinary-body body-forms-cst)
       (let* ((canonical-declaration-specifiers
               (cst:canonicalize-declarations system declaration-csts))
@@ -99,12 +99,12 @@
                 with result = (cst:cstify
                                (cons (cst:cst-from-expression 'locally)
                                      (if (null remaining-dspecs)
-                                         body-csts
+                                         (cst:listify forms-cst)
                                          (cons
                                           (cst:cons (cst:cst-from-expression 'declare)
                                                     remaining-dspecs-cst
                                                     :source (cst:source remaining-dspecs-cst))
-                                          body-csts))))
+                                          (cst:listify forms-cst)))))
                 for binding-cst in (reverse binding-csts)
                 for declaration-cst in (reverse item-specific-dspecs)
                 do (setf result

--- a/Code/Cleavir/CST-to-AST/convert-special.lisp
+++ b/Code/Cleavir/CST-to-AST/convert-special.lisp
@@ -283,7 +283,7 @@
   (check-argument-count cst 1 nil)
   (cst:db origin (flet-cst definitions-cst . body-cst) cst
     (declare (ignore flet-cst))
-    (multiple-value-bind (declaration-csts body-csts)
+    (multiple-value-bind (declaration-csts forms-cst)
         (cst:separate-ordinary-body body-cst)
       (let* ((canonical-declaration-specifiers
                (cst:canonicalize-declarations system declaration-csts))
@@ -298,9 +298,7 @@
                  ;; So that flet with empty body works.
                  (list
                   (process-progn
-                   (convert-sequence (cst:cstify body-csts)
-                                     final-env
-                                     system)))))))))
+                   (convert-sequence forms-cst final-env system)))))))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;
@@ -311,7 +309,7 @@
   (check-argument-count cst 1 nil)
   (cst:db origin (labels-cst definitions-cst . body-cst) cst
     (declare (ignore labels-cst))
-    (multiple-value-bind (declaration-csts body-csts)
+    (multiple-value-bind (declaration-csts forms-cst)
         (cst:separate-ordinary-body body-cst)
       (let* ((canonical-declaration-specifiers
                (cst:canonicalize-declarations system declaration-csts))
@@ -326,9 +324,7 @@
                  ;; So that flet with empty body works.
                  (list
                   (process-progn
-                   (convert-sequence (cst:cstify body-csts)
-                                     final-env
-                                     system)))))))))
+                   (convert-sequence forms-cst final-env system)))))))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;
@@ -705,12 +701,11 @@
   (check-cst-proper-list cst 'form-must-be-proper-list)
   (cst:db origin (locally-cst . body-forms-cst) cst
     (declare (ignore locally-cst))
-    (multiple-value-bind (declaration-csts body-csts)
+    (multiple-value-bind (declaration-csts forms-cst)
         (cst:separate-ordinary-body body-forms-cst)
       (let* ((canonical-declaration-specifiers
                (cst:canonicalize-declarations system declaration-csts))
              (new-env (augment-environment-with-declarations
-                       environment canonical-declaration-specifiers))
-             (body-cst (cst:cstify body-csts)))
+                       environment canonical-declaration-specifiers)))
         (with-preserved-toplevel-ness
-          (process-progn (convert-sequence body-cst new-env system)))))))
+          (process-progn (convert-sequence forms-cst new-env system)))))))


### PR DESCRIPTION
Specifically, the extracted body forms are now returned as a CST instance, not a Common Lisp list.