### PR TITLE
Allow EQ-AST to appear with one successor.

### DIFF
--- a/Code/Cleavir/Documentation/chap-primitive-operations.tex
+++ b/Code/Cleavir/Documentation/chap-primitive-operations.tex
@@ -45,8 +45,7 @@ function \texttt{cleavir-generate-ast:convert-special}.
 \Defprimop{eq} {object1 object2}
 
 This primitive operation has the same semantics as the \commonlisp{}
-function \texttt{eq}, except that it can only appear as the
-\emph{test-form} in the special form \texttt{if}.  Its main purpose is
+function \texttt{eq}.  Its main purpose is
 for defining the code for that \commonlisp{} function.  Typically the
 \commonlisp{} \texttt{eq} function will be declared \texttt{inline} so
 that the abstract syntax tree and HIR instruction resulting from this


### PR DESCRIPTION
This change removes the restriction that `EQ-AST` must be followed by two successors. Instead, when the case arises that `EQ-AST` has only one successor, `AST-HIR` conversion wraps the `EQ-AST` in an `IF`. This way, implementers can write `CL:EQ` as `(CLEAVIR-PRIMOP:EQ arg1 arg2)` and expect the right HIR graph to be generated, with no redundant branches needed.