### PR TITLE
Use worklists for remove-useless-instructions.

### DIFF
--- a/Code/Cleavir/HIR-transformations/Partial-inlining/inline-function.lisp
+++ b/Code/Cleavir/HIR-transformations/Partial-inlining/inline-function.lisp
@@ -109,4 +109,5 @@
                                 enter
                                 successor
                                 (mapping item))
-                               worklist)))))))
+                               worklist))))
+      (cleavir-ir:reinitialize-data initial))))


### PR DESCRIPTION
Builds with Clasp. Only negative slowdown observed.