### PR TITLE
More improvements to partial inlining

### DIFF
--- a/Code/Cleavir/HIR-transformations/Partial-inlining/copy-function.lisp
+++ b/Code/Cleavir/HIR-transformations/Partial-inlining/copy-function.lisp
@@ -93,6 +93,10 @@
                 (copy (cleavir-ir:clone-instruction instruction
                         :inputs new-inputs :outputs new-outputs
                         :dynamic-environment new-dynamic-environment)))
+           (typecase instruction
+             ((or cleavir-ir:enclose-instruction cleavir-ir:funcall-instruction)
+              (pushnew instruction *destinies-worklist*)
+              (pushnew copy *destinies-worklist*)))
            (disconnect-predecessor copy)
            (push copy copies)
            (setf (instruction-owner copy) *new-enter*)

--- a/Code/Cleavir/HIR-transformations/Partial-inlining/copy-function.lisp
+++ b/Code/Cleavir/HIR-transformations/Partial-inlining/copy-function.lisp
@@ -55,6 +55,7 @@
   (let ((copies nil)
         (stack (cons enter stack))
         (*new-enter* (cleavir-ir:clone-instruction enter)))
+    (disconnect-predecessor *new-enter*)
     (push *new-enter* copies)
     ;; Set up ownership.
     (setf (instruction-owner *new-enter*) *new-enter*)
@@ -86,6 +87,7 @@
                 (copy (cleavir-ir:clone-instruction instruction
                         :inputs new-inputs :outputs new-outputs
                         :dynamic-environment new-dynamic-environment)))
+           (disconnect-predecessor copy)
            (push copy copies)
            (setf (instruction-owner copy) *new-enter*)
            (add-to-mapping *instruction-mapping* instruction copy))))

--- a/Code/Cleavir/HIR-transformations/Partial-inlining/full-inlining-pass.lisp
+++ b/Code/Cleavir/HIR-transformations/Partial-inlining/full-inlining-pass.lisp
@@ -73,5 +73,5 @@
                (inline-function initial-instruction call enter (make-hash-table :test #'eq))
                (cleavir-remove-useless-instructions::remove-useless-instructions-from
                 initial-instruction function-defs)))
-             (cleavir-ir:set-predecessors initial-instruction))
+           (cleavir-ir:set-predecessors initial-instruction))
   (cleavir-remove-useless-instructions:remove-useless-instructions initial-instruction))

--- a/Code/Cleavir/HIR-transformations/Partial-inlining/full-inlining-pass.lisp
+++ b/Code/Cleavir/HIR-transformations/Partial-inlining/full-inlining-pass.lisp
@@ -72,6 +72,5 @@
              (let ((function-defs (cleavir-ir:defining-instructions (first (cleavir-ir:inputs call)))))
                (inline-function initial-instruction call enter (make-hash-table :test #'eq))
                (cleavir-remove-useless-instructions::remove-useless-instructions-from
-                initial-instruction function-defs)))
-           (cleavir-ir:set-predecessors initial-instruction))
+                initial-instruction function-defs))))
   (cleavir-remove-useless-instructions:remove-useless-instructions initial-instruction))

--- a/Code/Cleavir/HIR-transformations/Partial-inlining/full-inlining-pass.lisp
+++ b/Code/Cleavir/HIR-transformations/Partial-inlining/full-inlining-pass.lisp
@@ -11,49 +11,61 @@
 ;; get one potential inline that can be done, or else NIL.
 ;; An inline here is a list (enter call uniquep), where uniquep expresses whether the function
 ;; is not used for anything but this call.
-(defun one-potential-inline (initial-instruction dag)
-  (let ((destinies (cleavir-hir-transformations:compute-destinies initial-instruction)))
-    (let ((trappers (cleavir-hir-transformations:discern-trappers dag destinies)))
-      (labels ((maybe-return-inline (node)
-                 (let ((enter (cleavir-hir-transformations:enter-instruction node)))
-                   (when (and (all-parameters-required-p enter)
-                              (gethash enter trappers))
-                     ;; function's environment does not escape.
-                     ;; Now we just need to pick off any recursive uses, direct or indirect.
-                     (loop with enclose = (cleavir-hir-transformations:enclose-instruction node)
-                           with result
-                           with enclose-destinies = (gethash enclose destinies)
-                           with enclose-unique-p = (= (length enclose-destinies) 1)
-                           with enter-unique-p = (enter-unique-p enter dag)
-                           for caller in enclose-destinies
-                           when (eq caller :escape)
-                             return nil
-                           when (parent-node-p node (instruction-owner caller)) ; recursive
-                             return nil
-                           ;; We're all good, but keep looking through for escapes and recursivity.
-                           do (setf result (list enter caller node enclose-unique-p enter-unique-p))
-                           finally (return-from one-potential-inline result)))))
-               (parent-node-p (parent enter)
-                 ;; parent is a node (i.e. enclose), enter is an enter instruction
-                 ;; we return T iff the enter is enclosed by a node that has parent
-                 ;; as an ancestor.
-                 (let ((todo (gethash enter (cleavir-hir-transformations:dag-nodes dag))))
-                   (loop until (null todo)
-                         do (let ((test (pop todo)))
-                              (cond ((eq test dag) (return nil)) ; recursed all the way up
-                                    ((eq test parent) (return t))
-                                    (t (setf todo
-                                             (append todo
-                                                     (cleavir-hir-transformations:parents test)))))))))
-               (depth-first-search (node)
-                 (maybe-return-inline node)
-                 ;; It didn't return, so keep going.
-                 (mapc #'depth-first-search (cleavir-hir-transformations:children node))))
-        ;; We don't call maybe-return-inline on the toplevel function itself, since it obviously can't
-        ;; be inlined, and doesn't have an enclose-instruction, etc.
-        (mapc #'depth-first-search (cleavir-hir-transformations:children dag))
-        ;; No dice.
-        nil))))
+(defun one-potential-inline (dag destinies)
+  (let ((trappers (cleavir-hir-transformations:discern-trappers dag destinies)))
+    (labels ((maybe-return-inline (node)
+               (let ((enter (cleavir-hir-transformations:enter-instruction node)))
+                 (when (and (all-parameters-required-p enter)
+                            (gethash enter trappers))
+                   ;; function's environment does not escape.
+                   ;; Now we just need to pick off any recursive uses, direct or indirect.
+                   (loop with enclose = (cleavir-hir-transformations:enclose-instruction node)
+                         with result
+                         with enclose-destinies = (gethash enclose destinies)
+                         with enclose-unique-p = (= (length enclose-destinies) 1)
+                         with enter-unique-p = (enter-unique-p enter dag)
+                         for caller in enclose-destinies
+                         when (eq caller :escape)
+                           return nil
+                         when (parent-node-p node (instruction-owner caller)) ; recursive
+                           return nil
+                         ;; We're all good, but keep looking through for escapes and recursivity.
+                         do (setf result (list enter caller node enclose-unique-p enter-unique-p))
+                         finally (return-from one-potential-inline result)))))
+             (parent-node-p (parent enter)
+               ;; parent is a node (i.e. enclose), enter is an enter instruction
+               ;; we return T iff the enter is enclosed by a node that has parent
+               ;; as an ancestor.
+               (let ((todo (gethash enter (cleavir-hir-transformations:dag-nodes dag))))
+                 (loop until (null todo)
+                       do (let ((test (pop todo)))
+                            (cond ((eq test dag) (return nil)) ; recursed all the way up
+                                  ((eq test parent) (return t))
+                                  (t (setf todo
+                                           (append todo
+                                                   (cleavir-hir-transformations:parents test)))))))))
+             (depth-first-search (node)
+               (maybe-return-inline node)
+               ;; It didn't return, so keep going.
+               (mapc #'depth-first-search (cleavir-hir-transformations:children node))))
+      ;; We don't call maybe-return-inline on the toplevel function itself, since it obviously can't
+      ;; be inlined, and doesn't have an enclose-instruction, etc.
+      (mapc #'depth-first-search (cleavir-hir-transformations:children dag))
+      ;; No dice.
+      nil)))
+
+(defun update-destinies-map (worklist destinies-map)
+  (let ((encloses '()))
+    (dolist (thing worklist)
+      (etypecase thing
+        (cleavir-ir:enclose-instruction
+         (pushnew thing encloses))
+        (cleavir-ir:funcall-instruction
+         (dolist (enclose (cleavir-hir-transformations:destiny-find-encloses thing))
+           (pushnew enclose encloses)))))
+    (dolist (enclose encloses)
+      (setf (gethash enclose destinies-map)
+            (cleavir-hir-transformations:find-enclose-destinies enclose)))))
 
 (defun do-inlining (initial-instruction)
   ;; Need to remove all useless instructions first for incremental
@@ -64,16 +76,24 @@
         with *location-ownerships*
           = (cleavir-hir-transformations:compute-location-owners initial-instruction)
         with *function-dag* = (cleavir-hir-transformations:build-function-dag initial-instruction)
-        for inline = (one-potential-inline initial-instruction *function-dag*)
+        with *destinies-map* = (cleavir-hir-transformations:compute-destinies initial-instruction)
+        with *destinies-worklist* = '()
+        for inline = (one-potential-inline *function-dag* *destinies-map*)
         until (null inline)
-        do (destructuring-bind (enter call enclose enclose-unique-p enter-unique-p) inline
+        do (destructuring-bind (enter call node enclose-unique-p enter-unique-p) inline
              (declare (ignore enclose-unique-p enter-unique-p))
              ;; Find all instructions that could potentially be deleted after inlining.
-             (let ((function-defs (cleavir-ir:defining-instructions (first (cleavir-ir:inputs call)))))
+             (let ((function-defs (cleavir-ir:defining-instructions (first (cleavir-ir:inputs call))))
+                   (destinies-map *destinies-map*))
                (inline-function initial-instruction call enter (make-hash-table :test #'eq))
                (dolist (deleted
-                        (cleavir-remove-useless-instructions:remove-useless-instructions-from
-                         initial-instruction function-defs))
-                 (when (typep deleted 'cleavir-ir:enclose-instruction)
-                   (cleavir-hir-transformations:remove-enclose-from-function-dag *function-dag* deleted))))))
+                        (cleavir-remove-useless-instructions:remove-useless-instructions-from function-defs))
+                 (typecase deleted
+                   (cleavir-ir:enclose-instruction
+                    (cleavir-hir-transformations:remove-enclose-from-function-dag *function-dag* deleted))))
+               ;; The call is gone, so it is no longer a destiny.
+               (update-destinies-map (cons (cleavir-hir-transformations:enclose-instruction node)
+                                           *destinies-worklist*)
+                                     destinies-map)
+               (setf *destinies-worklist* nil))))
   (cleavir-remove-useless-instructions:remove-useless-instructions initial-instruction))

--- a/Code/Cleavir/HIR-transformations/Partial-inlining/inline-function.lisp
+++ b/Code/Cleavir/HIR-transformations/Partial-inlining/inline-function.lisp
@@ -109,5 +109,4 @@
                                 enter
                                 successor
                                 (mapping item))
-                               worklist))))
-      (cleavir-ir:reinitialize-data initial))))
+                               worklist)))))))

--- a/Code/Cleavir/HIR-transformations/Partial-inlining/inline-one-instruction.lisp
+++ b/Code/Cleavir/HIR-transformations/Partial-inlining/inline-one-instruction.lisp
@@ -100,13 +100,18 @@
                           (cleavir-ir:dynamic-environment instruction) mapping)))
 
 (defmethod copy-instruction ((instruction cleavir-ir:enclose-instruction) mapping)
-  (cleavir-ir:clone-instruction instruction
-    :inputs (translate-inputs (cleavir-ir:inputs instruction) mapping)
-    :outputs (translate-outputs (cleavir-ir:outputs instruction) mapping)
-    :predecessors nil :successors nil
-    :dynamic-environment (translate-input
-                          (cleavir-ir:dynamic-environment instruction) mapping)
-    :code (copy-function (cleavir-ir:code instruction) mapping)))
+  (let ((new-enclose
+          (cleavir-ir:clone-instruction
+           instruction
+           :inputs (translate-inputs (cleavir-ir:inputs instruction) mapping)
+           :outputs (translate-outputs (cleavir-ir:outputs instruction) mapping)
+           :predecessors nil :successors nil
+           :dynamic-environment (translate-input
+                                 (cleavir-ir:dynamic-environment instruction) mapping))))
+    ;; We hook things up like this so that the function DAG can be updated correctly.
+    (setf (cleavir-ir:code new-enclose)
+          (copy-function (cleavir-ir:code instruction) new-enclose mapping))
+    new-enclose))
 
 (defmethod copy-instruction ((instruction cleavir-ir:unwind-instruction) mapping)
   (let ((destination (cleavir-ir:destination instruction)))

--- a/Code/Cleavir/HIR-transformations/Partial-inlining/variables.lisp
+++ b/Code/Cleavir/HIR-transformations/Partial-inlining/variables.lisp
@@ -32,6 +32,9 @@
 
 (defvar *instruction-ownerships*)
 
+;;; This variable contains the function DAG.
+(defvar *function-dag*)
+
 ;;; Interface.
 (defun instruction-owner (instruction)
   (gethash instruction *instruction-ownerships*))

--- a/Code/Cleavir/HIR-transformations/Partial-inlining/variables.lisp
+++ b/Code/Cleavir/HIR-transformations/Partial-inlining/variables.lisp
@@ -35,6 +35,12 @@
 ;;; This variable contains the function DAG.
 (defvar *function-dag*)
 
+;;; This variable contains the map of ENCLOSE-INSTRUCTIONs to their destinies.
+(defvar *destinies-map*)
+
+;;; This variable keeps track of which INSTRUCTIONs affect the destinies-map.
+(defvar *destinies-worklist*)
+
 ;;; Interface.
 (defun instruction-owner (instruction)
   (gethash instruction *instruction-ownerships*))

--- a/Code/Cleavir/HIR-transformations/Remove-useless-instructions/packages.lisp
+++ b/Code/Cleavir/HIR-transformations/Remove-useless-instructions/packages.lisp
@@ -3,4 +3,5 @@
 (defpackage #:cleavir-remove-useless-instructions
   (:use #:common-lisp)
   (:export #:remove-useless-instructions
+           #:remove-useless-instructions-from
 	   #:instruction-may-be-removed-p))

--- a/Code/Cleavir/HIR-transformations/Remove-useless-instructions/remove-useless-instructions.lisp
+++ b/Code/Cleavir/HIR-transformations/Remove-useless-instructions/remove-useless-instructions.lisp
@@ -21,7 +21,7 @@
   nil)
 
 (defun remove-useless-instructions-with-worklist (initial-instruction worklist)
-  (let ((worklist worklist))
+  (let ((deleted '()))
     (loop (when (null worklist) (return))
           (let ((instruction (pop worklist)))
             (when (and (instruction-may-be-removed-p instruction)
@@ -36,7 +36,9 @@
                       (remove instruction (cleavir-ir:using-instructions input)))
                 (dolist (defining-instruction (cleavir-ir:defining-instructions input))
                   (push defining-instruction worklist)))
-              (cleavir-ir:delete-instruction instruction))))))
+              (push instruction deleted)
+              (cleavir-ir:delete-instruction instruction))))
+    deleted))
 
 (defun remove-useless-instructions (initial-instruction)
   (remove-useless-instructions-with-worklist initial-instruction
@@ -44,6 +46,6 @@
 
 ;;; An incremental version of remove-useless-instructions meant for
 ;;; clients which know where in the graph a potentially useless
-;;; instruction has appeared.
+;;; instruction has appeared.  Returns the instructions deleted.
 (defun remove-useless-instructions-from (initial-instruction instructions)
   (remove-useless-instructions-with-worklist initial-instruction instructions))

--- a/Code/Cleavir/HIR-transformations/Remove-useless-instructions/remove-useless-instructions.lisp
+++ b/Code/Cleavir/HIR-transformations/Remove-useless-instructions/remove-useless-instructions.lisp
@@ -20,7 +20,7 @@
   ;; using-instructions will be incorrect, therefore
   nil)
 
-(defun remove-useless-instructions-with-worklist (initial-instruction worklist)
+(defun remove-useless-instructions-with-worklist (worklist)
   (let ((deleted '()))
     (loop (when (null worklist) (return))
           (let ((instruction (pop worklist)))
@@ -41,11 +41,10 @@
     deleted))
 
 (defun remove-useless-instructions (initial-instruction)
-  (remove-useless-instructions-with-worklist initial-instruction
-                                             (cleavir-ir:instructions-of-type initial-instruction t)))
+  (remove-useless-instructions-with-worklist (cleavir-ir:instructions-of-type initial-instruction t)))
 
 ;;; An incremental version of remove-useless-instructions meant for
 ;;; clients which know where in the graph a potentially useless
 ;;; instruction has appeared.  Returns the instructions deleted.
-(defun remove-useless-instructions-from (initial-instruction instructions)
-  (remove-useless-instructions-with-worklist initial-instruction instructions))
+(defun remove-useless-instructions-from (instructions)
+  (remove-useless-instructions-with-worklist instructions))

--- a/Code/Cleavir/HIR-transformations/escape.lisp
+++ b/Code/Cleavir/HIR-transformations/escape.lisp
@@ -110,6 +110,44 @@
        (initial-instruction function-dag)))
     result))
 
+;;; An incremental version of compute destinies. Only compute the
+;;; destinies from a given enclose-instruction.
+(defun find-enclose-destinies (enclose-instruction)
+  (let ((destinies '())
+        (worklist (cleavir-ir:outputs enclose-instruction)))
+    (loop (when (null worklist)
+            (return destinies))
+          (let ((work (pop worklist)))
+            ;; note that we could hit the same work multiple times, so we use pushnew liberally.
+            (loop for next in (cleavir-ir:using-instructions work)
+                  do (typecase next
+                       ;; here is where we could allow other instructions, etc.
+                       (cleavir-ir:assignment-instruction
+                        (push (first (cleavir-ir:outputs next)) worklist))
+                       (call-instruction
+                        (if (eq work (first (cleavir-ir:inputs next)))
+                            ;; callee
+                            (pushnew next destinies :test #'eq)
+                            ;; arguments
+                            (pushnew :escape destinies :test #'eq)))
+                       (t ; treat as unknown
+                        (pushnew :escape destinies :test #'eq))))))))
+
+(defun destiny-find-encloses (call-instruction)
+  (let ((worklist (list (first (cleavir-ir:inputs call-instruction))))
+        (encloses '()))
+    (loop (when (null worklist)
+            (return encloses))
+          (let ((work (pop worklist)))
+            ;; note that we could hit the same work multiple times, so we use pushnew liberally.
+            (loop for next in (cleavir-ir:defining-instructions work)
+                  do (typecase next
+                       ;; here is where we could allow other instructions, etc.
+                       (cleavir-ir:assignment-instruction
+                        (push (first (cleavir-ir:inputs next)) worklist))
+                       (cleavir-ir:enclose-instruction
+                        (pushnew next encloses))))))))
+
 ;;; Compute a hash table from enclose instructions to "destinies".
 ;;; A destiny is a list. Elements of the list are either call instructions or :escape.
 ;;; Each list has no duplicates.
@@ -118,26 +156,8 @@
     (cleavir-ir:map-instructions-arbitrary-order
      (lambda (i)
        (when (typep i 'cleavir-ir:enclose-instruction)
-         (let ((destiny nil) (worklist (cleavir-ir:outputs i)))
-           (setf (gethash i destinies)
-                 (loop
-                   (if (null worklist)
-                       (return destiny) ; done
-                       (let ((work (pop worklist)))
-                         ;; note that we could hit the same work multiple times, so we use pushnew liberally.
-                         (loop for next in (cleavir-ir:using-instructions work)
-                               do (typecase next
-                                    ;; here is where we could allow other instructions, etc.
-                                    (cleavir-ir:assignment-instruction
-                                     (push (first (cleavir-ir:outputs next)) worklist))
-                                    (call-instruction
-                                     (if (eq work (first (cleavir-ir:inputs next)))
-                                         ;; callee
-                                         (pushnew next destiny :test #'eq)
-                                         ;; argument
-                                         (pushnew :escape destiny :test #'eq)))
-                                    (t ; treat as unknown
-                                     (pushnew :escape destiny :test #'eq)))))))))))
+         (setf (gethash i destinies)
+               (find-enclose-destinies i))))
      initial-instruction)
     destinies))
 

--- a/Code/Cleavir/HIR-transformations/function-dag.lisp
+++ b/Code/Cleavir/HIR-transformations/function-dag.lisp
@@ -61,3 +61,24 @@
 	   (push node (gethash (cleavir-ir:code instruction) table nil)))))
      initial-instruction)
     root))
+
+(defun remove-enclose-from-function-dag (dag enclose)
+  (let* ((table (dag-nodes dag))
+         (enter (cleavir-ir:code enclose))
+         (nodes (gethash enter table)))
+    (dolist (node nodes)
+      (when (eq (enclose-instruction node) enclose)
+        (dolist (parent (parents node))
+          (setf (children parent)
+                (remove node (children parent))))
+        (setf (gethash enter table)
+              (remove enclose nodes))
+        (return)))))
+
+(defun add-enclose-to-parents (enclose parents)
+  (let ((node (make-instance 'interior-node
+                             :parents parents
+                             :enclose-instruction enclose)))
+    (dolist (parent parents)
+      (push node (children parent)))
+    node))

--- a/Code/Cleavir/HIR-transformations/function-dag.lisp
+++ b/Code/Cleavir/HIR-transformations/function-dag.lisp
@@ -62,7 +62,10 @@
      initial-instruction)
     root))
 
-(defun remove-enclose-from-function-dag (dag enclose)
+;;; Removes an enclose instruction from the function-dag. If INHERIT
+;;; is true, then children of the deleted node are reattached to the
+;;; parent of the deleted node.
+(defun remove-enclose-from-function-dag (dag enclose &optional inherit)
   (let* ((table (dag-nodes dag))
          (enter (cleavir-ir:code enclose))
          (nodes (gethash enter table)))
@@ -70,7 +73,11 @@
       (when (eq (enclose-instruction node) enclose)
         (dolist (parent (parents node))
           (setf (children parent)
-                (remove node (children parent))))
+                (remove node (children parent)))
+          (when inherit
+            (dolist (child (children node))
+              (push child (children parent))
+              (nsubstitute parent node (parents child)))))
         (setf (gethash enter table)
               (remove enclose nodes))
         (return)))))

--- a/Code/Cleavir/HIR-transformations/function-dag.lisp
+++ b/Code/Cleavir/HIR-transformations/function-dag.lisp
@@ -1,17 +1,17 @@
 (cl:in-package #:cleavir-hir-transformations)
 
 ;;;; In this file we define functions for building and traversing a
-;;;; FUNCTION TREE.  Such a tree defines the nesting of functions in a
-;;;; program.  A node (other than the root) of the tree contains a
+;;;; FUNCTION DAG.  Such a dag defines the nesting of functions in a
+;;;; program.  A node (other than the root) of the dag contains a
 ;;;; slot holding an ENCLOSE-INSTRUCTION.  Each node contains a list
-;;;; of CHILDREN that are also tree nodes.  The children of a node N
+;;;; of CHILDREN that are also dag nodes.  The children of a node N
 ;;;; (other than the root) containing some ENCLOSE-INSTRUCTION E are
 ;;;; nodes that contain the ENCLOSE-INSTRUCTIONs owned by the CODE of
 ;;;; (i.e., the ENTER-INSTRUCTION associated with) E.  The children of
 ;;;; the root node are nodes containing the ENCLOSE-INSTRUCTIONs owned
 ;;;; by the ENTER-INSTRUCTION INITIAL-INSTRUCTION.  In addition to a
 ;;;; list of children, the root node also contains an EQ hash table
-;;;; that maps ENTER-INSTRUCTIONs to tree nodes such that the tree
+;;;; that maps ENTER-INSTRUCTIONs to tree nodes such that the dag
 ;;;; node is either the root, or it contains the ENCLOSE-INSTRUCTION
 ;;;; that the ENTER-INSTRUCTION is associated with.
 
@@ -38,11 +38,11 @@
 
 (defun build-function-dag (initial-instruction)
   (let* (;; Create an EQ hash table that maps ENTER-INSTRUCTIONs to
-	 ;; tree nodes such that the tree node is either the root, or
-	 ;; it contains the ENCLOSE-INSTRUCTION that the
+	 ;; dag nodes such that the dag node is either the root, or
+	 ;; it contains the ENCLOSE-INSTRUCTIONs that the
 	 ;; ENTER-INSTRUCTION is associated with.
 	 (table (make-hash-table :test #'eq))
-	 ;; Create the root of the tree that is ultimately going to be
+	 ;; Create the root of the dag that is ultimately going to be
 	 ;; returned as the value of this function.
 	 (root (make-instance 'function-dag
 		 :dag-nodes table

--- a/Code/Cleavir/HIR-transformations/packages.lisp
+++ b/Code/Cleavir/HIR-transformations/packages.lisp
@@ -31,4 +31,6 @@
    #:enclose-instruction
    #:dag-nodes
    #:parents
-   #:children))
+   #:children
+   #:remove-enclose-from-function-dag
+   #:add-enclose-to-parents))

--- a/Code/Cleavir/HIR-transformations/packages.lisp
+++ b/Code/Cleavir/HIR-transformations/packages.lisp
@@ -23,6 +23,8 @@
    #:maybe-eliminate)
   (:export
    #:compute-destinies
+   #:find-enclose-destinies
+   #:destiny-find-encloses
    #:discern-trappers
    #:discern-sharing)
   (:export


### PR DESCRIPTION
This removes the inner loop calls to reinitialize-data and set-predecessors. Clasp builds, but I am not 100% sure there aren't some regressions/incorrectness. It seems unlikely, given that Clasp builds in 2-3 hours less time with this patch for me.