### PR TITLE
Inline all closures

### DIFF
--- a/Code/Cleavir/HIR-transformations/Partial-inlining/inline-function.lisp
+++ b/Code/Cleavir/HIR-transformations/Partial-inlining/inline-function.lisp
@@ -28,7 +28,9 @@
        (when (typep instruction 'cleavir-ir:return-instruction)
          (push instruction returns))
        (when (typep instruction 'cleavir-ir:unwind-instruction)
-         (push instruction unwinds)))
+         (push instruction unwinds))
+       (when (typep instruction 'cleavir-ir:funcall-instruction)
+         (push instruction *destinies-worklist*)))
      enter)
     ;; We need to alter these. We find them before doing any alteration-
     ;; interleaving modification and finds results in unfortunate effects.

--- a/Code/Cleavir/HIR-transformations/Partial-inlining/inline-function.lisp
+++ b/Code/Cleavir/HIR-transformations/Partial-inlining/inline-function.lisp
@@ -3,7 +3,9 @@
 ;;; Cut and paste a function to inline - i.e. don't copy much of anything, which is nice,
 ;;; but means the original is destroyed.
 (defun interpolate-function (call enter)
-  (let ((returns '())
+  (let (;; We need to alter these. We find them before doing any alteration-
+        ;; interleaving modification and finds results in unfortunate effects.
+        (returns '())
         (unwinds '())
         (target-enter (instruction-owner call))
         (old-dynenv (cleavir-ir:dynamic-environment enter))
@@ -32,15 +34,17 @@
        (when (typep instruction 'cleavir-ir:funcall-instruction)
          (push instruction *destinies-worklist*)))
      enter)
-    ;; We need to alter these. We find them before doing any alteration-
-    ;; interleaving modification and finds results in unfortunate effects.
     ;; Make appropriate assignments to do the ENTER's task.
     (loop with cleavir-ir:*policy* = (cleavir-ir:policy call)
           with cleavir-ir:*dynamic-environment* = call-dynenv
           for location in (cleavir-ir:parameters enter)
           for arg in (rest (cleavir-ir:inputs call))
-          for assign = (cleavir-ir:make-assignment-instruction arg location)
-          do (cleavir-ir:insert-instruction-before assign call))
+          for assign = (cleavir-ir:make-assignment-instruction arg location) 
+          do (when (cleavir-ir:using-instructions location)
+               (let ((binding-assign (first (cleavir-ir:using-instructions location))))
+                 (change-class binding-assign 'binding-assignment-instruction)
+                 (push binding-assign *binding-assignments*)))
+             (cleavir-ir:insert-instruction-before assign call))
     ;; Turn any unwinds in the body to the function being inlined into
     ;; into direct control transfers.
     (loop with target-enter = (instruction-owner call)
@@ -98,7 +102,13 @@
                  for arg in (rest (cleavir-ir:inputs call))
                  for temp = (cleavir-ir:new-temporary)
                  for assign = (cleavir-ir:make-assignment-instruction arg temp)
-                 do (cleavir-ir:insert-instruction-before assign call)
+                 do (when (cleavir-ir:using-instructions location)
+                      (let ((binding-assign (first (cleavir-ir:using-instructions location))))
+                        ;; Don't have to push these onto the binding
+                        ;; assignment list, because only the clones
+                        ;; will end up needing cells.
+                        (change-class binding-assign 'binding-assignment-instruction)))
+                    (cleavir-ir:insert-instruction-before assign call)
                     (setf (instruction-owner assign) *target-enter-instruction*)
                     (add-to-mapping mapping location temp)
                     (setf (location-owner temp) *target-enter-instruction*)

--- a/Code/Cleavir/HIR-transformations/Partial-inlining/inline-one-instruction.lisp
+++ b/Code/Cleavir/HIR-transformations/Partial-inlining/inline-one-instruction.lisp
@@ -1,5 +1,15 @@
 (cl:in-package #:cleavir-partial-inlining)
 
+;;; This instruction is needed to distinguish assignments which arise
+;;; from actual bindings. Since the inliner removes enter-instructions
+;;; which serve to denote new variable bindings, we need to introduce
+;;; this instruction so that the inliner knows how to introduce cells
+;;; at the correct point of definition for those lexical variables
+;;; which need them. The read-only variable closure optimization
+;;; prevents us from double allocating cells unnecessarily, since
+;;; introduced cells are read-only locations.
+(defclass binding-assignment-instruction (cleavir-ir:assignment-instruction) ())
+
 ;;; Remove data references to old enter and call instructions for.
 (defun disconnect-enter-call-data (enter-instruction call-instruction)
   (dolist (input (cleavir-ir:inputs call-instruction))
@@ -96,6 +106,11 @@
     (pushnew instruction *destinies-worklist*)
     (pushnew result *destinies-worklist*)
     result))
+
+(defmethod copy-instruction :around ((instruction binding-assignment-instruction) mapping)
+  (let ((copy (call-next-method)))
+    (push copy *binding-assignments*)
+    copy))
 
 (defmethod copy-instruction (instruction mapping)
   (cleavir-ir:clone-instruction instruction

--- a/Code/Cleavir/HIR-transformations/Partial-inlining/variables.lisp
+++ b/Code/Cleavir/HIR-transformations/Partial-inlining/variables.lisp
@@ -41,6 +41,10 @@
 ;;; This variable keeps track of which INSTRUCTIONs affect the destinies-map.
 (defvar *destinies-worklist*)
 
+;;; This variable keeps a list of all binding assignments introduced
+;;; by the inliner.
+(defvar *binding-assignments*)
+
 ;;; Interface.
 (defun instruction-owner (instruction)
   (gethash instruction *instruction-ownerships*))

--- a/Code/Cleavir/HIR-transformations/packages.lisp
+++ b/Code/Cleavir/HIR-transformations/packages.lisp
@@ -13,6 +13,7 @@
    #:type-inference
    #:process-captured-variables
    #:segregate-only
+   #:read-only-location-p
    #:simplify-boxes
    #:compute-instruction-owners
    #:compute-location-owners

--- a/Code/Cleavir/HIR-transformations/packages.lisp
+++ b/Code/Cleavir/HIR-transformations/packages.lisp
@@ -21,7 +21,9 @@
    #:hir-transformations
    #:introduce-intermediate
    #:eliminate-superfluous-temporaries
-   #:maybe-eliminate)
+   #:maybe-eliminate
+   #:replace-inputs
+   #:replace-outputs)
   (:export
    #:compute-destinies
    #:find-enclose-destinies

--- a/Code/Cleavir/Intermediate-representation/graph-instructions.lisp
+++ b/Code/Cleavir/Intermediate-representation/graph-instructions.lisp
@@ -75,6 +75,7 @@
 (defclass enclose-instruction (instruction one-successor-mixin
                                allocation-mixin)
   ((%code :initarg :code :accessor code)
+   ;; Points to the instruction which initializes the closure environment.
    (%initializer :initarg :initializer :accessor initializer :initform nil)))  
 
 (defun make-enclose-instruction (output successor code)

--- a/Code/Cleavir/Intermediate-representation/graph-instructions.lisp
+++ b/Code/Cleavir/Intermediate-representation/graph-instructions.lisp
@@ -74,7 +74,8 @@
 
 (defclass enclose-instruction (instruction one-successor-mixin
                                allocation-mixin)
-  ((%code :initarg :code :accessor code)))  
+  ((%code :initarg :code :accessor code)
+   (%initializer :initarg :initializer :accessor initializer :initform nil)))  
 
 (defun make-enclose-instruction (output successor code)
   (make-instance 'enclose-instruction
@@ -83,4 +84,4 @@
     :code code))
 
 (defmethod clone-initargs append ((instruction enclose-instruction))
-  (list :code (code instruction)))
+  (list :code (code instruction) :initializer (initializer instruction)))

--- a/Code/Cleavir/Intermediate-representation/packages.lisp
+++ b/Code/Cleavir/Intermediate-representation/packages.lisp
@@ -57,7 +57,7 @@
    #:funcall-no-return-instruction #:make-funcall-no-return-instruction
    #:tailcall-instruction #:make-tailcall-instruction
    #:return-instruction #:make-return-instruction
-   #:enclose-instruction #:make-enclose-instruction #:code
+   #:enclose-instruction #:make-enclose-instruction #:code #:initializer
    #:initialize-closure-instruction #:make-initialize-closure-instruction
    #:typeq-instruction #:make-typeq-instruction #:value-type
    #:the-instruction #:make-the-instruction


### PR DESCRIPTION
Consider the code:

`(loop for x from 0 to 5
          collect (let ((i x))
                        (lambda () (setq i i) i))))`

Right now, there is a trapper criterion preventing the function created by LET from being inlined. However, the inliner can inline the LET by creating an assignment from x into i. However, this introduces a bug, because x and i would share their values, which is incorrect. Therefore, this change makes it so that the inliner marks the created assignment as a special subclass of assignment-instruction, then fixes up these special subclasses at the end of the inlining pass by allocating cells for those variables which need them. The upshot is that functions can be inlined regardless of how their subfunctions escape.

Incidentally, while this change chiefly benefits generated code, there is a slight built time improvement for clasp.