### PR TITLE
Fix tex-dependencies: replace echo -n with printf.

### DIFF
--- a/Code/Cleavir/Documentation/tex-dependencies
+++ b/Code/Cleavir/Documentation/tex-dependencies
@@ -2,9 +2,9 @@
 
 #set -x
 TEXFILES=$(./strip-dependence inputtex $1)
-echo -n $TEXFILES
+printf " $TEXFILES "
 for i in $TEXFILES
 do
-    echo -n " " $(./tex-dependencies $i)
+    printf " $(./tex-dependencies $i) "
 done
 echo

--- a/Code/Cleavir2/Documentation/tex-dependencies
+++ b/Code/Cleavir2/Documentation/tex-dependencies
@@ -2,9 +2,9 @@
 
 #set -x
 TEXFILES=$(./strip-dependence inputtex $1)
-echo -n $TEXFILES
+printf " $TEXFILES "
 for i in $TEXFILES
 do
-    echo -n " " $(./tex-dependencies $i)
+    printf " $(./tex-dependencies $i) "
 done
 echo

--- a/Papers/Bootstrapping/Talk/tex-dependencies
+++ b/Papers/Bootstrapping/Talk/tex-dependencies
@@ -1,6 +1,6 @@
 #!/bin/bash
 #set -x
-echo -n "$1 "
+printf "$1 "
 TEXFILES=$(./strip-dependence inputtex $1)
 for i in $TEXFILES
   do

--- a/Papers/Bootstrapping/tex-dependencies
+++ b/Papers/Bootstrapping/tex-dependencies
@@ -2,9 +2,9 @@
 
 #set -x
 TEXFILES=$(./strip-dependence inputtex $1)
-echo -n $TEXFILES
+printf " $TEXFILES "
 for i in $TEXFILES
 do
-    echo -n " " $(./tex-dependencies $i)
+    printf " $(./tex-dependencies $i) "
 done
 echo

--- a/Papers/ELS/tex-dependencies
+++ b/Papers/ELS/tex-dependencies
@@ -2,9 +2,9 @@
 
 #set -x
 TEXFILES=$(./strip-dependence inputtex $1)
-echo -n $TEXFILES
+printf " $TEXFILES "
 for i in $TEXFILES
 do
-    echo -n $(./tex-dependencies $i)
+    printf " $(./tex-dependencies $i) "
 done
 echo

--- a/Papers/Environment-info/tex-dependencies
+++ b/Papers/Environment-info/tex-dependencies
@@ -2,9 +2,9 @@
 
 #set -x
 TEXFILES=$(./strip-dependence inputtex $1)
-echo -n $TEXFILES
+printf " $TEXFILES "
 for i in $TEXFILES
 do
-    echo -n " " $(./tex-dependencies $i)
+    printf " $(./tex-dependencies $i) "
 done
 echo

--- a/Papers/Generic-dispatch/tex-dependencies
+++ b/Papers/Generic-dispatch/tex-dependencies
@@ -2,9 +2,9 @@
 
 #set -x
 TEXFILES=$(./strip-dependence inputtex $1)
-echo -n $TEXFILES
+printf " $TEXFILES "
 for i in $TEXFILES
 do
-    echo -n " " $(./tex-dependencies $i)
+    printf " $(./tex-dependencies $i) "
 done
 echo

--- a/Papers/Global-environments/Talk/tex-dependencies
+++ b/Papers/Global-environments/Talk/tex-dependencies
@@ -1,6 +1,6 @@
 #!/bin/bash
 #set -x
-echo -n "$1 "
+printf "$1 "
 TEXFILES=$(./strip-dependence inputtex $1)
 for i in $TEXFILES
   do

--- a/Papers/Global-environments/tex-dependencies
+++ b/Papers/Global-environments/tex-dependencies
@@ -2,9 +2,9 @@
 
 #set -x
 TEXFILES=$(./strip-dependence inputtex $1)
-echo -n $TEXFILES
+printf " $TEXFILES "
 for i in $TEXFILES
 do
-    echo -n " " $(./tex-dependencies $i)
+    printf " $(./tex-dependencies $i) "
 done
 echo

--- a/Papers/LOOP/Talk/tex-dependencies
+++ b/Papers/LOOP/Talk/tex-dependencies
@@ -1,6 +1,6 @@
 #!/bin/bash
 #set -x
-echo -n "$1 "
+printf "$1 "
 TEXFILES=$(./strip-dependence inputtex $1)
 for i in $TEXFILES
   do

--- a/Papers/LOOP/tex-dependencies
+++ b/Papers/LOOP/tex-dependencies
@@ -2,9 +2,9 @@
 
 #set -x
 TEXFILES=$(./strip-dependence inputtex $1)
-echo -n $TEXFILES
+printf " $TEXFILES "
 for i in $TEXFILES
 do
-    echo -n " " $(./tex-dependencies $i)
+    printf " $(./tex-dependencies $i) "
 done
 echo

--- a/Papers/Make-method-lambda/Talk/tex-dependencies
+++ b/Papers/Make-method-lambda/Talk/tex-dependencies
@@ -1,6 +1,6 @@
 #!/bin/bash
 #set -x
-echo -n "$1 "
+printf "$1 "
 TEXFILES=$(./strip-dependence inputtex $1)
 for i in $TEXFILES
   do

--- a/Papers/Make-method-lambda/tex-dependencies
+++ b/Papers/Make-method-lambda/tex-dependencies
@@ -2,9 +2,9 @@
 
 #set -x
 TEXFILES=$(./strip-dependence inputtex $1)
-echo -n $TEXFILES
+printf " $TEXFILES "
 for i in $TEXFILES
 do
-    echo -n " " $(./tex-dependencies $i)
+    printf " $(./tex-dependencies $i) "
 done
 echo

--- a/Papers/Merge-sort/tex-dependencies
+++ b/Papers/Merge-sort/tex-dependencies
@@ -2,9 +2,9 @@
 
 #set -x
 TEXFILES=$(./strip-dependence inputtex $1)
-echo -n $TEXFILES
+printf " $TEXFILES "
 for i in $TEXFILES
 do
-    echo -n " " $(./tex-dependencies $i)
+    printf " $(./tex-dependencies $i) "
 done
 echo

--- a/Papers/Partial-inlining/Talk/tex-dependencies
+++ b/Papers/Partial-inlining/Talk/tex-dependencies
@@ -1,6 +1,6 @@
 #!/bin/bash
 #set -x
-echo -n "$1 "
+printf "$1 "
 TEXFILES=$(./strip-dependence inputtex $1)
 for i in $TEXFILES
   do

--- a/Papers/Partial-inlining/tex-dependencies
+++ b/Papers/Partial-inlining/tex-dependencies
@@ -2,9 +2,9 @@
 
 #set -x
 TEXFILES=$(./strip-dependence inputtex $1)
-echo -n $TEXFILES
+printf " $TEXFILES "
 for i in $TEXFILES
 do
-    echo -n " " $(./tex-dependencies $i)
+    printf " $(./tex-dependencies $i) "
 done
 echo

--- a/Papers/Representing-method-combinations/tex-dependencies
+++ b/Papers/Representing-method-combinations/tex-dependencies
@@ -2,9 +2,9 @@
 
 #set -x
 TEXFILES=$(./strip-dependence inputtex $1)
-echo -n $TEXFILES
+printf " $TEXFILES "
 for i in $TEXFILES
 do
-    echo -n " " $(./tex-dependencies $i)
+    printf " $(./tex-dependencies $i) "
 done
 echo

--- a/Papers/Reverse-order/Talk/tex-dependencies
+++ b/Papers/Reverse-order/Talk/tex-dependencies
@@ -1,6 +1,6 @@
 #!/bin/bash
 #set -x
-echo -n "$1 "
+printf "$1 "
 TEXFILES=$(./strip-dependence inputtex $1)
 for i in $TEXFILES
   do

--- a/Papers/Reverse-order/tex-dependencies
+++ b/Papers/Reverse-order/tex-dependencies
@@ -2,9 +2,9 @@
 
 #set -x
 TEXFILES=$(./strip-dependence inputtex $1)
-echo -n $TEXFILES
+printf " $TEXFILES "
 for i in $TEXFILES
 do
-    echo -n " " $(./tex-dependencies $i)
+    printf " $(./tex-dependencies $i) "
 done
 echo

--- a/Papers/Rewrite/Talk/tex-dependencies
+++ b/Papers/Rewrite/Talk/tex-dependencies
@@ -1,6 +1,6 @@
 #!/bin/bash
 #set -x
-echo -n "$1 "
+printf "$1 "
 TEXFILES=$(./strip-dependence inputtex $1)
 for i in $TEXFILES
   do

--- a/Papers/Rewrite/tex-dependencies
+++ b/Papers/Rewrite/tex-dependencies
@@ -2,9 +2,9 @@
 
 #set -x
 TEXFILES=$(./strip-dependence inputtex $1)
-echo -n $TEXFILES
+printf " $TEXFILES "
 for i in $TEXFILES
 do
-    echo -n " " $(./tex-dependencies $i)
+    printf " $(./tex-dependencies $i) "
 done
 echo

--- a/Papers/Satiation/tex-dependencies
+++ b/Papers/Satiation/tex-dependencies
@@ -2,9 +2,9 @@
 
 #set -x
 TEXFILES=$(./strip-dependence inputtex $1)
-echo -n $TEXFILES
+printf " $TEXFILES "
 for i in $TEXFILES
 do
-    echo -n " " $(./tex-dependencies $i)
+    printf " $(./tex-dependencies $i) "
 done
 echo

--- a/Papers/Sequence-functions/Talk/tex-dependencies
+++ b/Papers/Sequence-functions/Talk/tex-dependencies
@@ -1,6 +1,6 @@
 #!/bin/bash
 #set -x
-echo -n "$1 "
+printf "$1 "
 TEXFILES=$(./strip-dependence inputtex $1)
 for i in $TEXFILES
   do

--- a/Papers/Sequence-functions/tex-dependencies
+++ b/Papers/Sequence-functions/tex-dependencies
@@ -2,9 +2,9 @@
 
 #set -x
 TEXFILES=$(./strip-dependence inputtex $1)
-echo -n $TEXFILES
+printf " $TEXFILES "
 for i in $TEXFILES
 do
-    echo -n " " $(./tex-dependencies $i)
+    printf " $(./tex-dependencies $i) "
 done
 echo

--- a/Papers/Sliding-GC/tex-dependencies
+++ b/Papers/Sliding-GC/tex-dependencies
@@ -2,9 +2,9 @@
 
 #set -x
 TEXFILES=$(./strip-dependence inputtex $1)
-echo -n $TEXFILES
+printf " $TEXFILES "
 for i in $TEXFILES
 do
-    echo -n " " $(./tex-dependencies $i)
+    printf " $(./tex-dependencies $i) "
 done
 echo

--- a/Papers/Type-inference/tex-dependencies
+++ b/Papers/Type-inference/tex-dependencies
@@ -2,9 +2,9 @@
 
 #set -x
 TEXFILES=$(./strip-dependence inputtex $1)
-echo -n $TEXFILES
+printf " $TEXFILES "
 for i in $TEXFILES
 do
-    echo -n " " $(./tex-dependencies $i)
+    printf " $(./tex-dependencies $i) "
 done
 echo

--- a/Specification/tex-dependencies
+++ b/Specification/tex-dependencies
@@ -2,9 +2,9 @@
 
 #set -x
 TEXFILES=$(./strip-dependence inputtex $1)
-echo -n $TEXFILES
+printf " $TEXFILES "
 for i in $TEXFILES
 do
-    echo -n " " $(./tex-dependencies $i)
+    printf " $(./tex-dependencies $i) "
 done
 echo

--- a/Talks/ILC-2014/tex-dependencies
+++ b/Talks/ILC-2014/tex-dependencies
@@ -2,9 +2,9 @@
 
 #set -x
 TEXFILES=$(./strip-dependence inputtex $1)
-echo -n $TEXFILES
+printf " $TEXFILES "
 for i in $TEXFILES
 do
-    echo -n " " $(./tex-dependencies $i)
+    printf " $(./tex-dependencies $i) "
 done
 echo


### PR DESCRIPTION
The dependency crawling would not complete on macOS / bash 5.0.9. The problem
caused by empty subdependencies lists, which lead to literal '-n's showing up in
the file list. At some point, the process hung waiting for input on an
invocation of tr.