### PR TITLE
Using \sloppy to prevent \texttt text to overflow.

### DIFF
--- a/Specification/sicl-specification.tex
+++ b/Specification/sicl-specification.tex
@@ -87,6 +87,7 @@ Building blocks for implementers of\\Common Lisp systems.}
 
 \makeindex
 \begin{document}
+\sloppy
 \pagenumbering{roman}
 
 \maketitle


### PR DESCRIPTION
For example, on page 80, section 17.2.3 "Accessor methods", two methods name are truncated because they are overflowing to the margin: "compute-discriminating-f..." and "compute-applicable-methods-using-cl...". Using \sloppy will fix that.