### PR TITLE
Propagate inline declarations up through HIR and use them.

### DIFF
--- a/Code/Cleavir/AST-to-HIR/compile-general-purpose-asts.lisp
+++ b/Code/Cleavir/AST-to-HIR/compile-general-purpose-asts.lisp
@@ -448,6 +448,9 @@
     (assert-context ast context nil 1)
     (let* ((all-args (cons (cleavir-ast:callee-ast ast)
                            (cleavir-ast:argument-asts ast)))
+           ;; Could do more sophisticated analysis for whether to
+           ;; mark an instruction as inlinable.
+           (inline (cleavir-ast:inline ast))
 	   (temps (make-temps all-args))
            ;; In case they diverge at some point.
            (inputs temps))
@@ -458,14 +461,16 @@
 	   (make-instance 'cleavir-ir:funcall-instruction
 	     :inputs inputs
 	     :outputs (list results)
-	     :successors successors)
+	     :successors successors
+             :inline inline)
 	   (let* ((values-temp (make-instance 'cleavir-ir:values-location)))
 	     (make-instance 'cleavir-ir:funcall-instruction
 	       :inputs inputs
 	       :outputs (list values-temp)
 	       :successors
 	       (list (cleavir-ir:make-multiple-to-fixed-instruction
-		      values-temp results (first successors))))))
+		      values-temp results (first successors)))
+               :inline inline)))
        context))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/Code/Cleavir/Abstract-syntax-tree/general-purpose-asts.lisp
+++ b/Code/Cleavir/Abstract-syntax-tree/general-purpose-asts.lisp
@@ -330,17 +330,20 @@
 
 (defclass call-ast (ast)
   ((%callee-ast :initarg :callee-ast :reader callee-ast)
-   (%argument-asts :initarg :argument-asts :reader argument-asts)))
+   (%argument-asts :initarg :argument-asts :reader argument-asts)
+   (%inline :initarg :inline :initform nil :reader inline)))
 
-(defun make-call-ast (callee-ast argument-asts &key origin (policy *policy*))
+(defun make-call-ast (callee-ast argument-asts &key origin inline (policy *policy*))
   (make-instance 'call-ast
     :origin origin :policy policy
     :callee-ast callee-ast
+    :inline inline
     :argument-asts argument-asts))
 
 (cleavir-io:define-save-info call-ast
   (:callee-ast callee-ast)
-  (:argument-asts argument-asts))
+  (:argument-asts argument-asts)
+  (:inline inline))
 
 (defmethod children ((ast call-ast))
   (list* (callee-ast ast) (argument-asts ast)))

--- a/Code/Cleavir/Abstract-syntax-tree/packages.lisp
+++ b/Code/Cleavir/Abstract-syntax-tree/packages.lisp
@@ -24,6 +24,7 @@
    #:constant-fdefinition-ast #:make-constant-fdefinition-ast #:info
    #:constant-symbol-value-ast #:make-constant-symbol-value-ast #:info
    #:call-ast #:make-call-ast #:callee-ast #:argument-asts
+   #:inline
    #:block-ast #:make-block-ast #:body
    #:function-ast #:make-function-ast #:lambda-list
    #:bound-declarations #:docstring #:original-lambda-list

--- a/Code/Cleavir/CST-to-AST/convert-cst.lisp
+++ b/Code/Cleavir/CST-to-AST/convert-cst.lisp
@@ -139,7 +139,8 @@
     (maybe-wrap-return
      function-type
      (cleavir-ast:make-call-ast function-ast argument-asts
-                                :origin (cst:source cst)))))
+                                :origin (cst:source cst)
+                                :inline (cleavir-env:inline info)))))
 
 ;;; Convert a form representing a call to a named global function.
 ;;; CST is the concrete syntax tree representing the entire

--- a/Code/Cleavir/CST-to-AST/convert-primop.lisp
+++ b/Code/Cleavir/CST-to-AST/convert-primop.lisp
@@ -351,7 +351,9 @@
      (loop for remaining = arguments-cst then (cst:rest remaining)
            until (cst:null remaining)
            collect (convert (cst:first remaining) env system))
-     :origin origin)))
+     :origin origin
+     ;; FIXME: propagate inline here somehow.
+     )))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;

--- a/Code/Cleavir/HIR-transformations/Partial-inlining/contify.lisp
+++ b/Code/Cleavir/HIR-transformations/Partial-inlining/contify.lisp
@@ -65,9 +65,14 @@
           ;; replacing every call's output with the return values of the
           ;; function.
           (otherwise
-           ;; We want error checking.
            (unless (every (lambda (user)
-                            (call-valid-p code user))
+                            ;; We want error checking.
+                            (and (call-valid-p code user)
+                                 ;; Explicit declaration should
+                                 ;; inhibit interpolation.
+                                 ;; Fix this when we start
+                                 ;; interpolating MVC.
+                                 (not (eq (inline user) 'notinline))))
                           users)
              (return-from interpolable-function-analyze-1))
            (interpolate-function return-point common-output common-dynenv code)

--- a/Code/Cleavir/HIR-transformations/Partial-inlining/full-inlining-pass.lisp
+++ b/Code/Cleavir/HIR-transformations/Partial-inlining/full-inlining-pass.lisp
@@ -40,9 +40,16 @@
                          return nil
                        when (parent-node-p node (instruction-owner caller)) ; recursive
                          return nil
-                       unless (call-valid-p enter caller) return nil
-                         ;; We're all good, but keep looking through for escapes and recursivity.
-                         do (setf result (list enter caller node enclose-unique-p enter-unique-p))
+                       ;; For now, since M-V-C doesn't track inlining
+                       ;; information, only check explicit inline
+                       ;; declarations for local functions.
+                       unless (or (typep caller 'cleavir-ir:multiple-value-call-instruction)
+                                  (eq (inline caller) 'inline))
+                         return nil
+                       unless (call-valid-p enter caller)
+                         return nil
+                       ;; We're all good, but keep looking through for escapes and recursivity.
+                       do (setf result (list enter caller node enclose-unique-p enter-unique-p))
                        finally (return-from one-potential-inline result)))))
            (parent-node-p (parent enter)
              ;; parent is a node (i.e. enclose), enter is an enter instruction

--- a/Code/Cleavir/Intermediate-representation/HIR/general-purpose-instructions.lisp
+++ b/Code/Cleavir/Intermediate-representation/HIR/general-purpose-instructions.lisp
@@ -82,6 +82,9 @@
     :successors (if successor-p (list successor) '())
     :inline inline))
 
+(defmethod clone-initargs append ((instruction funcall-instruction))
+  (list :inline (inline instruction)))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;
 ;;; Instruction FUNCALL-NO-RETURN-INSTRUCTION.
@@ -99,7 +102,7 @@
 
 (defun make-funcall-no-return-instruction (inputs)
   (make-instance 'funcall-no-return-instruction
-    :inputs inputs))
+                 :inputs inputs))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;

--- a/Code/Cleavir/Intermediate-representation/HIR/general-purpose-instructions.lisp
+++ b/Code/Cleavir/Intermediate-representation/HIR/general-purpose-instructions.lisp
@@ -72,14 +72,15 @@
 
 (defclass funcall-instruction
     (one-successor-mixin side-effect-mixin instruction)
-  ())
+  ((%inline :initarg :inline :initform nil :reader inline)))
 
 (defun make-funcall-instruction
-    (inputs outputs &optional (successor nil successor-p))
+    (inputs outputs &optional (successor nil successor-p) inline)
   (make-instance 'funcall-instruction
     :inputs inputs
     :outputs outputs
-    :successors (if successor-p (list successor) '())))
+    :successors (if successor-p (list successor) '())
+    :inline inline))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;


### PR DESCRIPTION
In particular, make sure interpolation doesn't happen whenever a call
is NOTINLINE and make sure full inlining happens only when a call is
INLINE.