### PR TITLE
Assorted inlining changes.

### DIFF
--- a/Code/Cleavir/AST-to-HIR/compile-general-purpose-asts.lisp
+++ b/Code/Cleavir/AST-to-HIR/compile-general-purpose-asts.lisp
@@ -450,7 +450,7 @@
                            (cleavir-ast:argument-asts ast)))
            ;; Could do more sophisticated analysis for whether to
            ;; mark an instruction as inlinable.
-           (inline (cleavir-ast:inline ast))
+           (inline (cleavir-ast:inline-declaration ast))
 	   (temps (make-temps all-args))
            ;; In case they diverge at some point.
            (inputs temps))

--- a/Code/Cleavir/Abstract-syntax-tree/general-purpose-asts.lisp
+++ b/Code/Cleavir/Abstract-syntax-tree/general-purpose-asts.lisp
@@ -331,7 +331,7 @@
 (defclass call-ast (ast)
   ((%callee-ast :initarg :callee-ast :reader callee-ast)
    (%argument-asts :initarg :argument-asts :reader argument-asts)
-   (%inline :initarg :inline :initform nil :reader inline)))
+   (%inline :initarg :inline :initform nil :reader inline-declaration)))
 
 (defun make-call-ast (callee-ast argument-asts &key origin inline (policy *policy*))
   (make-instance 'call-ast
@@ -343,7 +343,7 @@
 (cleavir-io:define-save-info call-ast
   (:callee-ast callee-ast)
   (:argument-asts argument-asts)
-  (:inline inline))
+  (:inline inline-declaration))
 
 (defmethod children ((ast call-ast))
   (list* (callee-ast ast) (argument-asts ast)))

--- a/Code/Cleavir/Abstract-syntax-tree/packages.lisp
+++ b/Code/Cleavir/Abstract-syntax-tree/packages.lisp
@@ -24,7 +24,7 @@
    #:constant-fdefinition-ast #:make-constant-fdefinition-ast #:info
    #:constant-symbol-value-ast #:make-constant-symbol-value-ast #:info
    #:call-ast #:make-call-ast #:callee-ast #:argument-asts
-   #:inline
+   #:inline-declaration
    #:block-ast #:make-block-ast #:body
    #:function-ast #:make-function-ast #:lambda-list
    #:bound-declarations #:docstring #:original-lambda-list

--- a/Code/Cleavir/HIR-transformations/Partial-inlining/contify.lisp
+++ b/Code/Cleavir/HIR-transformations/Partial-inlining/contify.lisp
@@ -74,7 +74,7 @@
                                  ;; inhibit interpolation.
                                  ;; Fix this when we start
                                  ;; interpolating MVC.
-                                 (not (eq (inline user) 'notinline))))
+                                 (not (eq (cleavir-ir:inline-declaration user) 'notinline))))
                           users)
              (return-from interpolable-function-analyze-1))
            (interpolate-function return-point common-output common-dynenv code)

--- a/Code/Cleavir/HIR-transformations/Partial-inlining/contify.lisp
+++ b/Code/Cleavir/HIR-transformations/Partial-inlining/contify.lisp
@@ -5,10 +5,10 @@
 (defun copy-propagate-assignment (assignment)
   (let ((input (first (cleavir-ir:inputs assignment)))
         (output (first (cleavir-ir:outputs assignment))))
-    ;; Without reaching definitions, input must have one definition
-    ;; and output must have one use.
+    ;; Without reaching definitions, the output and input must *both*
+    ;; have only one definition, the initial one.
     (when (and (null (rest (cleavir-ir:defining-instructions input)))
-               (null (rest (cleavir-ir:using-instructions output))))
+               (null (rest (cleavir-ir:defining-instructions output))))
       ;; Some assignments are totally useless.
       (if (eq input output)
           (cleavir-ir:delete-instruction assignment)

--- a/Code/Cleavir/HIR-transformations/Partial-inlining/full-inlining-pass.lisp
+++ b/Code/Cleavir/HIR-transformations/Partial-inlining/full-inlining-pass.lisp
@@ -43,7 +43,7 @@
                        ;; information, only check explicit inline
                        ;; declarations for local functions.
                        unless (or (typep user 'cleavir-ir:multiple-value-call-instruction)
-                                  (eq (inline user) 'inline))
+                                  (eq (cleavir-ir:inline-declaration user) 'inline))
                          return nil
                        unless (call-valid-p enter user)
                          return nil

--- a/Code/Cleavir/HIR-transformations/Partial-inlining/inline-one-instruction.lisp
+++ b/Code/Cleavir/HIR-transformations/Partial-inlining/inline-one-instruction.lisp
@@ -101,12 +101,6 @@
     (setf (instruction-owner result) *target-enter-instruction*)
     result))
 
-(defmethod copy-instruction :around ((instruction cleavir-ir:funcall-instruction) mapping)
-  (let* ((result (call-next-method)))
-    (pushnew instruction *destinies-worklist*)
-    (pushnew result *destinies-worklist*)
-    result))
-
 (defmethod copy-instruction :around ((instruction binding-assignment-instruction) mapping)
   (let ((copy (call-next-method)))
     (push copy *binding-assignments*)
@@ -129,8 +123,6 @@
            :predecessors nil :successors nil
            :dynamic-environment (translate-input
                                  (cleavir-ir:dynamic-environment instruction) mapping))))
-    (pushnew instruction *destinies-worklist*)
-    (pushnew new-enclose *destinies-worklist*)
     ;; We hook things up like this so that the function DAG can be updated correctly.
     (setf (cleavir-ir:code new-enclose)
           (copy-function (cleavir-ir:code instruction) new-enclose mapping))

--- a/Code/Cleavir/HIR-transformations/Partial-inlining/variables.lisp
+++ b/Code/Cleavir/HIR-transformations/Partial-inlining/variables.lisp
@@ -35,12 +35,6 @@
 ;;; This variable contains the function DAG.
 (defvar *function-dag*)
 
-;;; This variable contains the map of ENCLOSE-INSTRUCTIONs to their destinies.
-(defvar *destinies-map*)
-
-;;; This variable keeps track of which INSTRUCTIONs affect the destinies-map.
-(defvar *destinies-worklist*)
-
 ;;; This variable keeps a list of all binding assignments introduced
 ;;; by the inliner.
 (defvar *binding-assignments*)

--- a/Code/Cleavir/HIR-transformations/escape.lisp
+++ b/Code/Cleavir/HIR-transformations/escape.lisp
@@ -110,57 +110,6 @@
        (initial-instruction function-dag)))
     result))
 
-;;; An incremental version of compute destinies. Only compute the
-;;; destinies from a given enclose-instruction.
-(defun find-enclose-destinies (enclose-instruction)
-  (let ((destinies '())
-        (worklist (cleavir-ir:outputs enclose-instruction)))
-    (loop (when (null worklist)
-            (return destinies))
-          (let ((work (pop worklist)))
-            ;; note that we could hit the same work multiple times, so we use pushnew liberally.
-            (loop for next in (cleavir-ir:using-instructions work)
-                  do (typecase next
-                       ;; here is where we could allow other instructions, etc.
-                       (cleavir-ir:assignment-instruction
-                        (push (first (cleavir-ir:outputs next)) worklist))
-                       (call-instruction
-                        (if (eq work (first (cleavir-ir:inputs next)))
-                            ;; callee
-                            (pushnew next destinies :test #'eq)
-                            ;; arguments
-                            (pushnew :escape destinies :test #'eq)))
-                       (t ; treat as unknown
-                        (pushnew :escape destinies :test #'eq))))))))
-
-(defun destiny-find-encloses (call-instruction)
-  (let ((worklist (list (first (cleavir-ir:inputs call-instruction))))
-        (encloses '()))
-    (loop (when (null worklist)
-            (return encloses))
-          (let ((work (pop worklist)))
-            ;; note that we could hit the same work multiple times, so we use pushnew liberally.
-            (loop for next in (cleavir-ir:defining-instructions work)
-                  do (typecase next
-                       ;; here is where we could allow other instructions, etc.
-                       (cleavir-ir:assignment-instruction
-                        (push (first (cleavir-ir:inputs next)) worklist))
-                       (cleavir-ir:enclose-instruction
-                        (pushnew next encloses))))))))
-
-;;; Compute a hash table from enclose instructions to "destinies".
-;;; A destiny is a list. Elements of the list are either call instructions or :escape.
-;;; Each list has no duplicates.
-(defun compute-destinies (initial-instruction)
-  (let ((destinies (make-hash-table :test #'eq)))
-    (cleavir-ir:map-instructions-arbitrary-order
-     (lambda (i)
-       (when (typep i 'cleavir-ir:enclose-instruction)
-         (setf (gethash i destinies)
-               (find-enclose-destinies i))))
-     initial-instruction)
-    destinies))
-
 ;;; Compute a hash table from call instructions to "origins".
 ;;; An origin is a list. Elements of the list are either enclose instructions,
 ;;; fdefinition instructions, or :unknown. Each list has no duplicates.

--- a/Code/Cleavir/Intermediate-representation/HIR/general-purpose-instructions.lisp
+++ b/Code/Cleavir/Intermediate-representation/HIR/general-purpose-instructions.lisp
@@ -72,7 +72,7 @@
 
 (defclass funcall-instruction
     (one-successor-mixin side-effect-mixin instruction)
-  ((%inline :initarg :inline :initform nil :reader inline)))
+  ((%inline :initarg :inline :initform nil :reader inline-declaration)))
 
 (defun make-funcall-instruction
     (inputs outputs &optional (successor nil successor-p) inline)
@@ -83,7 +83,7 @@
     :inline inline))
 
 (defmethod clone-initargs append ((instruction funcall-instruction))
-  (list :inline (inline instruction)))
+  (list :inline (inline-declaration instruction)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;

--- a/Code/Cleavir/Intermediate-representation/packages.lisp
+++ b/Code/Cleavir/Intermediate-representation/packages.lisp
@@ -53,7 +53,7 @@
    #:nop-instruction #:make-nop-instruction
    #:unreachable-instruction #:make-unreachable-instruction
    #:assignment-instruction #:make-assignment-instruction
-   #:funcall-instruction #:make-funcall-instruction
+   #:funcall-instruction #:make-funcall-instruction #:inline-declaration
    #:funcall-no-return-instruction #:make-funcall-no-return-instruction
    #:tailcall-instruction #:make-tailcall-instruction
    #:return-instruction #:make-return-instruction


### PR DESCRIPTION
Cases like (let ((f (lambda () 4)))
             (print (funcall f))
             (setf f (lambda ())
             (funcall f)))
would do the wrong thing. Fix this by getting rid of destinies
analysis and replacing it with copy propagation, which significantly
simplifies the code, and also cleans up the graph at the same time.