### PR TITLE
Some improvements to hash tables

### DIFF
--- a/Code/Hash-tables/Buckets/bucket-hash-table-defclass-extrinsic.lisp
+++ b/Code/Hash-tables/Buckets/bucket-hash-table-defclass-extrinsic.lisp
@@ -1,7 +1,17 @@
 (cl:in-package #:sicl-bucket-hash-table)
 
 (defclass bucket-hash-table (hash-table)
-  ((%size :initform 0 :initarg :size :accessor size :reader hash-table-size)
-   (%contents :initform '() :accessor contents)))
+  ((size :initarg :size
+         :initform 16
+         :accessor %bucket-hash-table-size
+         :reader hash-table-size)
+   (data :accessor hash-table-data)
+   (hash-function :initarg :hash-function
+                  :accessor hash-table-hash-function)
+   (offset :initform (random (expt 2 64))
+           :reader hash-table-offset)
+   (count :initform 0
+          :accessor %bucket-hash-table-count
+          :reader hash-table-count)))
 
 (setf sicl-hash-table:*default-hash-table-class* (find-class 'bucket-hash-table))

--- a/Code/Hash-tables/Buckets/bucket-hash-table-defclass.lisp
+++ b/Code/Hash-tables/Buckets/bucket-hash-table-defclass.lisp
@@ -6,6 +6,10 @@
          :accessor %bucket-hash-table-size
          :reader hash-table-size)
    (data :accessor hash-table-data)
+   (hash-function :initarg :hash-function
+                  :accessor hash-table-hash-function)
+   (offset :initform (random (expt 2 64))
+           :reader hash-table-offset)
    (count :initform 0
           :accessor %bucket-hash-table-count
           :reader hash-table-count)))

--- a/Code/Hash-tables/Buckets/packages-extrinsic.lisp
+++ b/Code/Hash-tables/Buckets/packages-extrinsic.lisp
@@ -9,6 +9,7 @@
    #:hash-table-size #:hash-table-test #:%hash-table-test
    #:puthash #:gethash #:remhash #:clrhash
    #:with-hash-table-iterator
+   #:find-hash-function
    #:maphash)
   (:use #:common-lisp)
   (:export #:bucket-hash-table))

--- a/Code/Hash-tables/Buckets/packages.lisp
+++ b/Code/Hash-tables/Buckets/packages.lisp
@@ -1,4 +1,9 @@
 (cl:in-package #:common-lisp-user)
 
 (defpackage #:sicl-bucket-hash-table
-  (:use #:common-lisp))
+  (:import-from #:sicl-hash-table
+                #:find-hash-function
+                #:with-hash-table-iterator
+                #:%hash-table-test)
+  (:use #:common-lisp)
+  (:export #:bucket-hash-table))

--- a/Code/Hash-tables/generic-functions.lisp
+++ b/Code/Hash-tables/generic-functions.lisp
@@ -43,3 +43,10 @@
 
 ;;; Internal
 (defgeneric make-hash-table-iterator (hash-table))
+
+(defmethod print-object ((table hash-table) stream)
+  (print-unreadable-object (table stream :type t :identity t)
+    (format stream ":test ~s size ~d/~d"
+            (hash-table-test table)
+            (hash-table-count table)
+            (hash-table-size table))))

--- a/Code/Hash-tables/make-hash-table.lisp
+++ b/Code/Hash-tables/make-hash-table.lisp
@@ -4,7 +4,8 @@
 
 (defun make-hash-table (&rest rest
                         &key (test 'eql) size rehash-size rehash-threshold
-                             (class *default-hash-table-class*))
+                             (class *default-hash-table-class*)
+                        &allow-other-keys)
   (declare (ignore test size rehash-size rehash-threshold))
   (apply #'make-instance class
          (append (loop for (keyword value) on rest by #'cddr

--- a/Code/Hash-tables/packages-extrinsic.lisp
+++ b/Code/Hash-tables/packages-extrinsic.lisp
@@ -4,7 +4,8 @@
   (:use #:common-lisp)
   ;; Shadow these for now.  Ultimately, import them with
   ;; the rest of the CL package. 
-  (:shadow #:hash-table
+  (:shadow #:sxhash
+           #:hash-table
            #:make-hash-table #:hash-table-p
            #:hash-table-count #:hash-table-rehash-threshold #:hash-table-rehash-size
            #:hash-table-size #:hash-table-test
@@ -12,10 +13,11 @@
            #:with-hash-table-iterator
            #:maphash)
   (:export #:*default-hash-table-class*
+           #:sxhash #:eq-hash #:equal-hash #:equalp-hash #:find-hash-function
            #:hash-table
            #:make-hash-table #:hash-table-p
            #:hash-table-count #:hash-table-rehash-threshold #:hash-table-rehash-size
-           #:hash-table-size #:hash-table-test
+           #:hash-table-size #:hash-table-test #:%hash-table-test
            #:puthash #:gethash #:remhash #:clrhash
            #:with-hash-table-iterator
            #:maphash

--- a/Code/Hash-tables/packages.lisp
+++ b/Code/Hash-tables/packages.lisp
@@ -2,4 +2,8 @@
 
 (defpackage #:sicl-hash-table
   (:use #:common-lisp)
-  (:export #:*default-hash-table-class* #:make-hash-table-iterator))
+  (:export #:*default-hash-table-class*
+           #:eq-hash #:equal-hash #:equalp-hash
+           #:%hash-table-test
+           #:find-hash-function #:sxhash
+           #:make-hash-table-iterator))

--- a/Code/Hash-tables/sicl-hash-table-base-extrinsic.asd
+++ b/Code/Hash-tables/sicl-hash-table-base-extrinsic.asd
@@ -6,4 +6,5 @@
   ((:file "packages-extrinsic")
    (:file "hash-table-defclass-extrinsic")
    (:file "generic-functions")
+   (:file "sxhash")
    (:file "make-hash-table")))

--- a/Code/Hash-tables/sicl-hash-table-base.asd
+++ b/Code/Hash-tables/sicl-hash-table-base.asd
@@ -6,4 +6,5 @@
   ((:file "packages")
    (:file "hash-table-defclass")
    (:file "generic-functions")
+   (:file "sxhash")
    (:file "make-hash-table")))

--- a/Code/Hash-tables/sicl-hash-table.asd
+++ b/Code/Hash-tables/sicl-hash-table.asd
@@ -5,4 +5,4 @@
                #:sicl-list-hash-table)
   :serial t
   :components
-  ((:file with-hash-table-iterator-defmacro)))
+  ((:file "with-hash-table-iterator-defmacro")))

--- a/Code/Hash-tables/sxhash.lisp
+++ b/Code/Hash-tables/sxhash.lisp
@@ -86,7 +86,8 @@
 
 (defvar *sxhash-offset* 14695981039346656037)
 (defun sxhash (object)
-  (equal-hash *sxhash-offset* object))
+  (ldb (byte 62 0)
+       (equal-hash *sxhash-offset* object)))
 
 (defvar *hash-functions*
   `((eq  . ,#'eq-hash)

--- a/Code/Hash-tables/sxhash.lisp
+++ b/Code/Hash-tables/sxhash.lisp
@@ -1,0 +1,101 @@
+(cl:in-package #:sicl-hash-table)
+
+(defconstant +fnv-prime+ 1099511628211)
+
+(declaim (inline %fnv-1a fnv-1a)
+         (optimize (speed 3)))
+(defun %fnv-1a (last-hash byte)
+  (declare ((unsigned-byte 8) byte)
+           ((unsigned-byte 64) last-hash))
+  (ldb (byte 64 0)
+       (logxor (* last-hash +fnv-prime+)
+               byte)))
+
+(defun fnv-1a (last-hash &rest bytes)
+  (declare ((unsigned-byte 64) last-hash))
+  (reduce #'%fnv-1a bytes :initial-value last-hash))
+
+(define-compiler-macro fnv-1a (last-hash &rest bytes)
+  (reduce (lambda (last-form argument)
+            `(%fnv-1a ,last-form ,argument))
+          bytes
+          :initial-value last-hash))
+
+(defun eq-hash (last-hash object)
+  (typecase object
+    ;; Instances of a built-in-class can't change-class, so we can gather some
+    ;; entropy from their classes at the very least.
+    (cons      (fnv-1a last-hash 1))
+    (character (let ((code (char-code object)))
+                 (fnv-1a last-hash
+                         2
+                         (ldb (byte 8 0) code)
+                         (ldb (byte 8 8) code))))
+    (integer   (fnv-1a last-hash
+                       3
+                       (ldb (byte 8 0) object)
+                       (ldb (byte 8 8) object)))
+    (float     (multiple-value-bind (significand exponent)
+                   (integer-decode-float object)
+                 (fnv-1a last-hash
+                         4
+                         (ldb (byte 8 0) significand)
+                         (ldb (byte 8 8) significand)
+                         (ldb (byte 8 0) exponent))))
+    ;; The element-type of an array won't change.
+    (array     (fnv-1a (equal-hash last-hash (array-element-type object))
+                       2))
+    (symbol    (equal-hash last-hash (symbol-name object)))
+    (t last-hash)))
+
+(defvar *depth* 3)
+(defun equal-hash (last-hash object)
+  (when (zerop *depth*)
+    (return-from equal-hash last-hash))
+  (typecase object
+    (cons (let ((*depth* (1- *depth*)))
+            (equal-hash (equal-hash last-hash (car object))
+                        (cdr object))))
+    (symbol (equal-hash (fnv-1a last-hash 1)
+                        (symbol-name object)))
+    (string (loop for char across object
+                  for position below 16
+                  for hash = last-hash then (equal-hash last-hash char)
+                  finally (return hash)))
+    (t (eq-hash last-hash object))))
+
+(defun equalp-hash (last-hash object)
+  (when (zerop *depth*)
+    (return-from equalp-hash last-hash))
+  (typecase object
+    (cons (let ((*depth* (1- *depth*)))
+            (equalp-hash (equalp-hash last-hash (car object))
+                         (cdr object))))
+    (symbol (equal-hash (fnv-1a last-hash 1)
+                        (symbol-name object)))
+    (character (eq-hash last-hash (char-downcase object)))
+    (string (loop for char across object
+                  for position below 16
+                  for hash = last-hash then (equalp-hash hash char)
+                  finally (return hash)))
+    (array (loop with size = (array-total-size object)
+                 for position below size
+                 for hash = last-hash then (equalp-hash last-hash
+                                                        (aref object position))))
+    (t (eq-hash last-hash object))))
+
+(defvar *sxhash-offset* 14695981039346656037)
+(defun sxhash (object)
+  (equal-hash *sxhash-offset* object))
+
+(defvar *hash-functions*
+  `((eq  . ,#'eq-hash)
+    (eql . ,#'eq-hash)
+    (equal  . ,#'equal-hash)
+    (equalp . ,#'equalp-hash))
+  "A list of pairs of test function names and their respective hash functions.")
+(defun find-hash-function (name)
+  (let ((pair (assoc name *hash-functions*)))
+    (if (null pair)
+        (error "No hash function found for the test ~s" name)
+        (cdr pair))))

--- a/README.md
+++ b/README.md
@@ -6,8 +6,7 @@ standard library, and documentation.
 
 ## What is SICL?
 
-SICL is a new implementation of Common
-Lisp. It is intentionally
+SICL is a new implementation of Common Lisp. It is intentionally
 divided into many implementation-independent modules that are written
 in a totally or near-totally portable way, so as to allow other
 implementations to incorporate these modules from SICL, rather than
@@ -18,11 +17,13 @@ versions.
 
 1. Make sure you have installed the dependencies:
 
+[the Cluster repository]:https://github.com/robert-strandh/Cluster
 [the Concrete-Syntax-Tree repository]:https://github.com/robert-strandh/Concrete-Syntax-Tree
 [the Eclector repository]:https://github.com/robert-strandh/Eclector
 [the Trucler repository]:https://github.com/robert-strandh/Trucler
 
    * A recent 64-bit version of SBCL
+   * The system "cluster" from [the Cluster repository]
    * The system "concrete-syntax-tree" from [the Concrete-Syntax-Tree repository]
    * The system "eclector", from [the Eclector repository]
    * The system "trucler-reference", from [the Trucler repository]


### PR DESCRIPTION
- `bucket-hash-table`s have random "offsets", which are used to ensure hash tables hash their keys differently, making complexity attacks much more difficult.
- Some portable hash functions have been added (`sicl-hash-table:eq-hash`, `equal-hash`, `equalp-hash`), as well as an implementation of `sxhash`. (`eq-hash` admittedly has very little to work with, but should perform well with numeric and symbol keys.)
- Custom hash functions can be provided to `bucket-hash-table`s through the `:hash-function` keyword argument, which takes an unsigned 64-bit offset and an object to hash and returns an unsigned 64-bit hash.
- A `print-object` method was defined for hash tables, which prints something like `#<SICL-BUCKET-HASH-TABLE:BUCKET-HASH-TABLE :test #<FUNCTION STRING=> size 1/16 {101C3C3253}>` (using custom hash and test functions).

- Oh, and Cluster was added as a dependency to the README.