### PR TITLE
That alist of standard hash functions was not redundant.

### DIFF
--- a/Code/Hash-tables/sxhash.lisp
+++ b/Code/Hash-tables/sxhash.lisp
@@ -91,8 +91,13 @@
   (ldb (byte 62 0)
        (equal-hash *sxhash-offset* object)))
 
+(defvar *standard-hash-functions*
+  `((eq     . ,#'eq-hash)
+    (eql    . ,#'eq-hash)
+    (equal  . ,#'equal-hash)
+    (equalp . ,#'equalp-hash)))
 (defun find-hash-function (name)
-  (let ((pair (assoc name *standard-tests*)))
+  (let ((pair (assoc name *standard-hash-functions*)))
     (if (null pair)
         (error "No hash function found for the test ~s" name)
         (cdr pair))))


### PR DESCRIPTION
I made `find-hash-function` use the alist of standard test functions, and that went terribly. This pull request fixes that.

Usually messing that sort of thing up only happens after 9pm. Oh well. 