### PR TITLE
type-infer: Explicitly mark values as having T type on confluence.

### DIFF
--- a/Code/Cleavir/HIR-transformations/value-type-infer.lisp
+++ b/Code/Cleavir/HIR-transformations/value-type-infer.lisp
@@ -486,9 +486,9 @@
                   (unless (typep (cleavir-basic-blocks:last-instruction predecessor)
                                  'cleavir-ir:choke-instruction)
                     (unless (gethash value (table (out-constraints predecessor)))
-                      ;; Mark the value as being T type implicitly by
-                      ;; removal from table.
-                      (remhash value (table constraint-table))))))
+                      (setf (gethash value (table constraint-table))
+                            (make-typeq-constraint value
+                                                   (cleavir-ctype:top system)))))))
               (table (out-constraints predecessor))))))
        (setf (in-constraints block) constraint-table))))
   (in-constraints block))


### PR DESCRIPTION
Relying on implicit marking by removal from table causes
non-deterministic behavior as removing type constraints from the table
causes the behavior to be dependent on the order in which basic blocks
are collected. The union operation on type constraints treats a value
not having a constraint specially to make value -> Top type mappings
implicit for space efficiency, but this interacts with confluence
badly.