### PR TITLE
Improve using-instructions tracking

### DIFF
--- a/Code/Cleavir2/HIR-transformations/Remove-useless-instructions/remove-useless-instructions.lisp
+++ b/Code/Cleavir2/HIR-transformations/Remove-useless-instructions/remove-useless-instructions.lisp
@@ -8,12 +8,6 @@
              always (null (cleavir-ir:using-instructions output)))))
 
 (defmethod instruction-may-be-removed-p
-    ((instruction cleavir-ir:save-values-instruction))
-  ;; Remove SAVE-VALUES-INSTRUCTIONs if the saved values are never used.
-  (null (cleavir-ir:using-instructions
-         (first (cleavir-ir:outputs instruction)))))
-
-(defmethod instruction-may-be-removed-p
     ((instruction cleavir-ir:side-effect-mixin))
   nil)
 

--- a/Code/Cleavir2/HIR-transformations/Remove-useless-instructions/remove-useless-instructions.lisp
+++ b/Code/Cleavir2/HIR-transformations/Remove-useless-instructions/remove-useless-instructions.lisp
@@ -8,6 +8,12 @@
              always (null (cleavir-ir:using-instructions output)))))
 
 (defmethod instruction-may-be-removed-p
+    ((instruction cleavir-ir:save-values-instruction))
+  ;; Remove SAVE-VALUES-INSTRUCTIONs if the saved values are never used.
+  (null (cleavir-ir:using-instructions
+         (first (cleavir-ir:outputs instruction)))))
+
+(defmethod instruction-may-be-removed-p
     ((instruction cleavir-ir:side-effect-mixin))
   nil)
 

--- a/Code/Cleavir2/HIR-transformations/cleavir2-hir-transformations.asd
+++ b/Code/Cleavir2/HIR-transformations/cleavir2-hir-transformations.asd
@@ -5,6 +5,7 @@
   :serial t
   :components
   ((:file "packages")
+   (:file "eliminate-catches")
    (:file "compute-ownership")
    (:file "function-dag")
    (:file "escape")

--- a/Code/Cleavir2/HIR-transformations/eliminate-catches.lisp
+++ b/Code/Cleavir2/HIR-transformations/eliminate-catches.lisp
@@ -1,0 +1,31 @@
+(in-package #:cleavir-hir-transformations)
+
+;;;; Eliminates CATCH-INSTRUCTIONS with unused continuations.
+;;;; Because they have multiple successors, this is not suitable
+;;;; for inclusion in the general remove-useless-instructions.
+
+(defun dead-catch-p (instruction)
+  (and (typep instruction 'cleavir-ir:catch-instruction)
+       (let ((cont (first (cleavir-ir:outputs instruction))))
+         (null (cleavir-ir:using-instructions cont)))))
+
+(defun eliminate-catches (initial-instruction)
+  (let ((death nil))
+    (cleavir-ir:map-instructions-arbitrary-order
+     (lambda (instruction)
+       ;; Update instruction dynenvs by zooming up the nesting until a
+       ;; live dynenv is reached.
+       (do* ((dynenv (cleavir-ir:dynamic-environment-location instruction)
+                     (cleavir-ir:dynamic-environment-location dynenv-definer))
+             (dynenv-definer (first (cleavir-ir:defining-instructions dynenv))
+                             (first (cleavir-ir:defining-instructions dynenv))))
+           ((not (dead-catch-p dynenv-definer))
+            (setf (cleavir-ir:dynamic-environment-location instruction) dynenv)))
+       (when (dead-catch-p instruction)
+         (push instruction death)))
+     initial-instruction)
+    (dolist (catch death)
+      ;; Modify the flow graph.
+      (cleavir-ir:bypass-instruction (first (cleavir-ir:successors catch)) catch))
+    (cleavir-ir:reinitialize-data initial-instruction)
+    death))

--- a/Code/Cleavir2/HIR-transformations/packages.lisp
+++ b/Code/Cleavir2/HIR-transformations/packages.lisp
@@ -3,6 +3,7 @@
 (defpackage #:cleavir-hir-transformations
   (:use #:common-lisp)
   (:export
+   #:eliminate-catches
    #:segregate-only
    #:segregate-lexicals
    #:replace-inputs

--- a/Code/Cleavir2/Intermediate-representation/HIR/multiple-value-related-instructions.lisp
+++ b/Code/Cleavir2/Intermediate-representation/HIR/multiple-value-related-instructions.lisp
@@ -73,19 +73,12 @@
 ;;; Instruction SAVE-VALUES-INSTRUCTION.
 ;;;
 ;;; This instruction has a single output which is a lexical location
-;;; holding a the dynamic environment.  The instruction takes the
+;;; holding the augmented dynamic environment.  The instruction takes the
 ;;; values in the global values location and creates a new values
 ;;; entry to be the top of the dynamic environment.  The output holds
 ;;; the augmented dynamic environment.
 
-;;; FIXME: this instruction should not be a subclass of
-;;; SIDE-EFFECT-MIXIN.  It is temporarily the case until we fix
-;;; REMOVE-USELESS-INSTRUCTIONS to take dynamic environment locations
-;;; into account.  Right now, the output of this instruction is
-;;; considered not used, so the instruction gets removed.
-
-(defclass save-values-instruction
-    (instruction one-successor-mixin side-effect-mixin)
+(defclass save-values-instruction (instruction one-successor-mixin)
   ())
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/Code/Cleavir2/Intermediate-representation/Visualizer/gui.lisp
+++ b/Code/Cleavir2/Intermediate-representation/Visualizer/gui.lisp
@@ -61,7 +61,7 @@
         append enter-instructions))
 
 (defun layout-program (enter-instruction pane)
-  (loop for hpos = 10 then (+ hpos (+ rack-width horizontal-node-separation))
+  (loop for hpos = 50 then (+ hpos (+ rack-width horizontal-node-separation))
         for rack = (list enter-instruction) then (next-rack rack)
         for dimensions = (loop for inst in rack
                                collect (multiple-value-bind (width height)


### PR DESCRIPTION
This commit adds instructions as users of their dynamic environment locations when they are initialized, and when the location is replaced, mirroring the tracking done on inputs and outputs.

As such, `save-values-instruction` does not need to subclass `side-effect-mixin` to avoid incorrect removal, because its uses are tracked correctly now. We also move IR drawn in the visualiser a bit to the right to accommodate for long instruction names, and port `eliminate-catches` to Cleavir2.