### PR TITLE
Correct MAKE-HASH-TABLE-ITERATOR for bucket hash tables.

### DIFF
--- a/Code/Hash-tables/Buckets/bucket-hash-table.lisp
+++ b/Code/Hash-tables/Buckets/bucket-hash-table.lisp
@@ -15,12 +15,16 @@
         (contents '()))
     (lambda ()
       (block hash-table-iterator
+        ;; Look for the next bucket which contains mappings.
         (loop while (null contents)
               when (= position size)
-                do (return-from hash-table-iterator (values nil nil))
+                ;; When we run out of mappings, we return the single value NIL.
+                do (return-from hash-table-iterator nil)
               do (setf contents (aref data position))
                  (incf position))
-        (pop contents)))))
+        ;; Otherwise, we return values T, key and value.
+        (let ((entry (pop contents)))
+          (values t (car entry) (cdr entry)))))))
 
 (defun grow-and-rehash (hash-table)
   (let* ((new-size (if (integerp (hash-table-rehash-size hash-table))
@@ -78,8 +82,7 @@
     (not (null entry))))
 
 (defmethod clrhash ((hash-table bucket-hash-table))
-  (loop for index below (hash-table-size hash-table)
-        do (setf (aref (hash-table-data hash-table) index) nil))
+  (fill (hash-table-data hash-table) '())
   (setf (%bucket-hash-table-count hash-table) 0)
   hash-table)
 

--- a/Code/Hash-tables/make-hash-table.lisp
+++ b/Code/Hash-tables/make-hash-table.lisp
@@ -2,6 +2,11 @@
 
 (defvar *default-hash-table-class*)
 
+(defmethod initialize-instance :after ((hash-table hash-table) &key)
+  (assert (> (hash-table-rehash-size hash-table) 1)
+          ()
+          "The rehash-size must be greater than 1."))
+
 (defun make-hash-table (&rest rest
                         &key (test 'eql) size rehash-size rehash-threshold
                              (class *default-hash-table-class*)


### PR DESCRIPTION
We also check that we haven't been fooled into shrinking (or otherwise not growing) a hash table with a `:resize-size` less than or equal to 1.