### PR TITLE
Setup suggestions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ versions.
 [the Eclector repository]:https://github.com/s-expressionists/Eclector
 [the Trucler repository]:https://github.com/s-expressionists/Trucler
 [the Clostrum repository]:https://github.com/s-expressionists/Clostrum
+[the Incless repository]:https://github.com/s-expressionists/incless
 
    * A recent 64-bit version of SBCL
    * The system "cluster" from [the Cluster repository]
@@ -29,6 +30,7 @@ versions.
    * The system "eclector", from [the Eclector repository]
    * The system "trucler-reference", from [the Trucler repository]
    * The system "clostrum", from [the Clostrum repository]
+   * The system "incless-intrinsic", from [the Incless repository]
 
 2. Clone the [source] with `git`:
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ versions.
    * The system "clostrum", from [the Clostrum repository]
    * The system "incless-intrinsic", from [the Incless repository]
 
+The bash script `get-dependencies.sh` will do this work for you.
+
 2. Clone the [source] with `git`:
 
    ```

--- a/get-dependencies.sh
+++ b/get-dependencies.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+set -euo pipefail
+
+#
+# Add dependencies URLs here
+#
+DEPENDENCIES="
+https://github.com/robert-strandh/Cluster
+https://github.com/s-expressionists/Concrete-Syntax-Tree
+https://github.com/s-expressionists/Eclector
+https://github.com/s-expressionists/Trucler
+https://github.com/s-expressionists/Clostrum
+https://github.com/s-expressionists/incless
+"
+
+PROJECTS_DIRECTORY=${1:-"~/quicklisp/local-projects/"}
+
+if [ ! -d $PROJECTS_DIRECTORY ]; then
+    cat <<EOF
+Usage: $0 [PROJECTS_DIRECTORY].
+
+You did not supply a directory to download dependencies into;
+the default diretory "$PROJECTS_DIRECTORY" does not exist.
+
+EOF
+    exit 1
+fi
+
+pushd $PROJECTS_DIRECTORY
+
+for url in $DEPENDENCIES; do
+    repository_name=`basename $url`
+
+    if [ -d "$repository_name" ]; then
+        echo " * pulling updates for $repository_name";
+        pushd $repository_name
+        git pull
+        popd
+    else
+        echo " * cloning $repository_name";
+        git clone $url
+    fi
+done
+
+cat <<EOF
+Done.
+
+Run (ql:register-local-projects) from your REPL to add
+any new systems to your environment.
+
+EOF


### PR DESCRIPTION
This adds a bash script to prepare new dependencies or update existing ones.

It also adds Incless as a dependency for the REDME.md file, and mentions the shell script below that list of dependencies.

Without arguments, the script assumes quicklisp was installed in its default place; if error messages should be more helpful, one could suggest running `(directory-namestring (first ql::*local-project-directories*))` to find the actual setting.