### PR TITLE
Fix env var expansion issues in dependencies script

### DIFF
--- a/get-dependencies.sh
+++ b/get-dependencies.sh
@@ -13,9 +13,9 @@ https://github.com/s-expressionists/Clostrum
 https://github.com/s-expressionists/incless
 "
 
-PROJECTS_DIRECTORY=${1:-"~/quicklisp/local-projects/"}
+PROJECTS_DIRECTORY=${1:-"$HOME/quicklisp/local-projects/"}
 
-if [ ! -d $PROJECTS_DIRECTORY ]; then
+if [ ! -d "$PROJECTS_DIRECTORY" ]; then
     cat <<EOF
 Usage: $0 [PROJECTS_DIRECTORY].
 
@@ -26,7 +26,7 @@ EOF
     exit 1
 fi
 
-pushd $PROJECTS_DIRECTORY
+pushd "$PROJECTS_DIRECTORY"
 
 for url in $DEPENDENCIES; do
     repository_name=`basename $url`

--- a/get-dependencies.sh
+++ b/get-dependencies.sh
@@ -20,7 +20,7 @@ if [ ! -d "$PROJECTS_DIRECTORY" ]; then
 Usage: $0 [PROJECTS_DIRECTORY].
 
 You did not supply a directory to download dependencies into;
-the default diretory "$PROJECTS_DIRECTORY" does not exist.
+the default directory "$PROJECTS_DIRECTORY" does not exist.
 
 EOF
     exit 1


### PR DESCRIPTION
Proposed fix for Issue: https://github.com/robert-strandh/SICL/issues/195

Changes: Replaced tilde with `$HOME` in the default directory path, quoted uses of the relevant environment variable, fixed a small typo in the error message.