### PR TITLE
Slightly restructure sicl-random and add a PCG32 implementation

### DIFF
--- a/Code/Random/mersenne-twister.lisp
+++ b/Code/Random/mersenne-twister.lisp
@@ -1,0 +1,62 @@
+(cl:in-package #:sicl-random)
+
+(defconstant +mt19937-bits+ 32)
+(defconstant +mt19937-size+ 624)
+(defconstant +mt19937-period+ 397)
+(defconstant +mt19937-a+ #x9908B0DF)
+(defconstant +mt19937-u+ 29)
+(defconstant +mt19937-s+ 7)
+(defconstant +mt19937-b+ #x9D2C5680)
+(defconstant +mt19937-t+ 15)
+(defconstant +mt19937-c+ #xEFC60000)
+(defconstant +mt19937-l+ 18)
+(defconstant +mt19937-lower-mask+ #x7FFFFFFF)
+(defconstant +mt19937-upper-mask+ #x80000000)
+
+(defmethod seed-random-state ((state mt19937-random) (seed fixnum))
+  (setf (aref (state-array state) 0) seed)
+  (loop :for i :from 1 :below +mt19937-size+
+     :for xi-1 := (aref (state-array state) (1- i))
+     :do
+       (setf (aref (state-array state) i)
+             (logand #xFFFFFFFF
+                     (+ i (* 1812433253 (logxor xi-1 (ash xi-1 -30)))))))
+  (setf (index state) +mt19937-size+))
+
+(defmethod read-random-state ((state mt19937-random))
+  (flet ((twist (state)
+           (loop :for i :from 0 :below +mt19937-size+ :do
+                (let* ((x (+ (logand (aref (state-array state) i)
+                                     +mt19937-upper-mask+)
+                             (logand (aref (state-array state)
+                                           (mod (1+ i) +mt19937-size+))
+                                     +mt19937-lower-mask+)))
+                       (xa (ash x -1)))
+                  (when (= 1 (ldb (byte 1 0) x))
+                    (setf xa (logxor xa +mt19937-a+)))
+                  (setf (aref (state-array state) i)
+                        (logxor
+                         (aref (state-array state)
+                               (mod (+ i +mt19937-period+) +mt19937-size+))
+                         xa))))
+           (setf (index state) 0)))
+    (when (> (index state) +mt19937-size+)
+      (error "Never seeded."))
+    (when (= (index state) +mt19937-size+)
+      (twist state))
+    (let* ((y (aref (state-array state) (index state)))
+           (y (logxor y (ash y (- +mt19937-u+))))
+           (y (logxor y (logand (ash y +mt19937-s+) +mt19937-b+)))
+           (y (logxor y (logand (ash y +mt19937-t+) +mt19937-c+)))
+           (y (logxor y (ash y -1))))
+      (incf (index state))
+      (ldb (byte +mt19937-bits+ 0) y))))
+
+(defmethod copy-random-state ((state mt19937-random))
+  (make-instance 'mt19937-random
+                 :index (index state)
+                 :state-array (copy-seq (state-array state))))
+
+(defmethod print-object ((object mt19937-random) stream)
+  (format stream "#.(make-instance 'sicl-random::mt19937-random :index ~D :state-array ~S)"
+          (index object) (state-array object)))

--- a/Code/Random/pcg32.lisp
+++ b/Code/Random/pcg32.lisp
@@ -1,0 +1,38 @@
+(cl:in-package #:sicl-random)
+
+(defmethod seed-random-state ((state pcg32-random) (seed fixnum))
+  ;; This algorithm has something they call streams. Supporting this is not
+  ;; something I'm going to bother to do since it can't properly be exposed
+  ;; through CL's PRNG functions. I set it to 27 here since that's what the
+  ;; PCG32 demo seems to do if it's not given a different number. If you find
+  ;; this inadequate, feel free to improve it.
+  (setf (state-num state) 0
+        (increment state) 3)
+  (read-random-state state)
+  (incf (state-num state) seed)
+  (read-random-state state))
+
+(defmethod read-random-state ((state pcg32-random))
+  (let ((old-state (state-num state))
+        (increment (increment state)))
+    (declare (type (unsigned-byte 64) old-state increment))
+    (setf (state-num state) (ldb (byte 64 0)
+                                 (*  old-state
+                                     (+ 6364136223846793005
+                                        (logior increment 1)))))
+    (let ((xor-shifted (ldb (byte 32 0)
+                            (ash (logxor (ash old-state -18) old-state)
+                                 -27)))
+          (rotation (ldb (byte 32 0) (ash old-state -59))))
+      (declare (type (unsigned-byte 32) xor-shifted rotation))
+      (logior (ash xor-shifted (- rotation))
+              (ash xor-shifted (logand (- rotation) 31))))))
+
+(defmethod copy-random-state ((state pcg32-random))
+  (make-instance 'pcg32-random
+                 :increment (increment state)
+                 :state-num (state-num state)))
+
+(defmethod print-object ((object pcg32-random) stream)
+  (format stream "#.(make-instance 'sicl-random::mt19937-random :increment ~D :state-num ~S)"
+          (increment object) (state-num object)))

--- a/Code/Random/random-state-defclass.lisp
+++ b/Code/Random/random-state-defclass.lisp
@@ -23,3 +23,20 @@
    (%index :initform (1+ +mt19937-size+)
            :initarg :index
            :accessor index)))
+
+(defgeneric state-num (random-state))
+
+(defgeneric (setf state-num) (state-num random-state))
+
+(defgeneric increment (random-state))
+
+(defgeneric (setf increment) (increment random-state))
+
+(defclass pcg32-random (random-state)
+  ((%random-bits :initform 32)
+   (%state-num :initarg :state-num
+               :accessor state-num
+               :type (unsigned-byte 64))
+   (%increment :initarg :increment
+               :accessor increment
+               :type (unsigned-byte 64))))

--- a/Code/Random/random-state-defgeneric.lisp
+++ b/Code/Random/random-state-defgeneric.lisp
@@ -1,0 +1,8 @@
+(cl:in-package #:sicl-random)
+
+(defgeneric seed-random-state (state seed)
+  (:documentation "Initializes and sets the initial seed of STATE."))
+(defgeneric read-random-state (state)
+  (:documentation "Returns the next random number from STATE and prepares the next one."))
+(defgeneric copy-random-state (state)
+  (:documentation "Returns a new object which is a copy of STATE."))

--- a/Code/Random/random.lisp
+++ b/Code/Random/random.lisp
@@ -1,17 +1,10 @@
 (cl:in-package #:sicl-random)
 
-(defgeneric seed-random-state (state seed)
-  (:documentation "Initializes and sets the initial seed of STATE."))
-(defgeneric read-random-state (state)
-  (:documentation "Returns the next random number from STATE and prepares the next one."))
-(defgeneric copy-random-state (state)
-  (:documentation "Returns a new object which is a copy of STATE."))
+(defparameter *default-random-state-class-name* 'mt19937-random)
+(defvar *random-state*)
 
 (defun random-state-p (object)
   (typep object 'random-state))
-
-(defparameter *default-random-state-class-name* 'mt19937-random)
-(defvar *random-state*)
 
 (defun random-float (limit random-state)
   (declare (type float limit))
@@ -46,72 +39,7 @@
           ((null state)
            (copy-random-state *random-state*)))))
 
-;;; Mersenne Twister (MT19937)
-
-(defconstant +mt19937-bits+ 32)
-(defconstant +mt19937-size+ 624)
-(defconstant +mt19937-period+ 397)
-(defconstant +mt19937-a+ #x9908B0DF)
-(defconstant +mt19937-u+ 29)
-(defconstant +mt19937-s+ 7)
-(defconstant +mt19937-b+ #x9D2C5680)
-(defconstant +mt19937-t+ 15)
-(defconstant +mt19937-c+ #xEFC60000)
-(defconstant +mt19937-l+ 18)
-(defconstant +mt19937-lower-mask+ #x7FFFFFFF)
-(defconstant +mt19937-upper-mask+ #x80000000)
-
-(defmethod seed-random-state ((state mt19937-random) (seed fixnum))
-  (setf (aref (state-array state) 0) seed)
-  (loop :for i :from 1 :below +mt19937-size+
-     :for xi-1 := (aref (state-array state) (1- i))
-     :do
-       (setf (aref (state-array state) i)
-             (logand #xFFFFFFFF
-                     (+ i (* 1812433253 (logxor xi-1 (ash xi-1 -30)))))))
-  (setf (index state) +mt19937-size+))
-
-(defmethod read-random-state ((state mt19937-random))
-  (flet ((twist (state)
-           (loop :for i :from 0 :below +mt19937-size+ :do
-                (let* ((x (+ (logand (aref (state-array state) i)
-                                     +mt19937-upper-mask+)
-                             (logand (aref (state-array state)
-                                           (mod (1+ i) +mt19937-size+))
-                                     +mt19937-lower-mask+)))
-                       (xa (ash x -1)))
-                  (when (= 1 (ldb (byte 1 0) x))
-                    (setf xa (logxor xa +mt19937-a+)))
-                  (setf (aref (state-array state) i)
-                        (logxor
-                         (aref (state-array state)
-                               (mod (+ i +mt19937-period+) +mt19937-size+))
-                         xa))))
-           (setf (index state) 0)))
-    (when (> (index state) +mt19937-size+)
-      (error "Never seeded."))
-    (when (= (index state) +mt19937-size+)
-      (twist state))
-    (let* ((y (aref (state-array state) (index state)))
-           (y (logxor y (ash y (- +mt19937-u+))))
-           (y (logxor y (logand (ash y +mt19937-s+) +mt19937-b+)))
-           (y (logxor y (logand (ash y +mt19937-t+) +mt19937-c+)))
-           (y (logxor y (ash y -1))))
-      (incf (index state))
-      (ldb (byte +mt19937-bits+ 0) y))))
-
-(defmethod copy-random-state ((state mt19937-random))
-  (make-instance 'mt19937-random
-                 :index (index state)
-                 :state-array (copy-seq (state-array state))))
-
-(defmethod print-object ((object mt19937-random) stream)
-  (format stream "#.(make-instance 'sicl-random::mt19937-random :index ~D :state-array ~S)"
-          (index object) (state-array object)))
-
-;;; Sets the initial *random-state*
-
-(setf *random-state* (make-random-state t))
+(setf *random-state* (make-random-state t)) ; Sets the initial *random-state*
 
 (defun random (limit &optional (random-state *random-state*))
   "Returns a non-negative pseudo-random number that is less than LIMIT."

--- a/Code/Random/sicl-random-intrinsic.asd
+++ b/Code/Random/sicl-random-intrinsic.asd
@@ -5,4 +5,7 @@
   :components
   ((:file "packages-intrinsic")
    (:file "random-state-defclass")
+   (:file "random-state-defgeneric")
+   (:file "mersenne-twister")
+   (:file "pcg32")
    (:file "random")))

--- a/Code/Random/sicl-random.asd
+++ b/Code/Random/sicl-random.asd
@@ -5,4 +5,7 @@
   :components
   ((:file "packages")
    (:file "random-state-defclass")
+   (:file "random-state-defgeneric")
+   (:file "mersenne-twister")
+   (:file "pcg32")
    (:file "random")))


### PR DESCRIPTION
The "slight restructuring" is just moving the Mersenne Twister methods into a separate file. PCG32 is not used by default, but can be enabled by `(setf sicl-random::*default-random-state-class-name* 'sicl-random::pcg32-random)` followed by `(setf *random-state* (make-random-state t))`. I'd like to get opinions on this before it's merged.