### PR TITLE
Fix register allocation for SHIFT-INSTRUCTION and others

### DIFF
--- a/Code/Cleavir/Intermediate-representation/packages.lisp
+++ b/Code/Cleavir/Intermediate-representation/packages.lisp
@@ -163,6 +163,7 @@
    #:unsigned-not-greater-instruction
    #:negate-instruction
    #:equal-instruction
+   #:shift-instruction
    #:shift-left-instruction
    #:logic-shift-right-instruction
    #:arithmetic-shift-right-instruction

--- a/Code/Compiler/MIR-to-LIR/Register-allocation/allocate-register.lisp
+++ b/Code/Compiler/MIR-to-LIR/Register-allocation/allocate-register.lisp
@@ -147,6 +147,7 @@
          instruction)
         assignment))))
 
+(defvar *registers-to-avoid* (x86-64:make-register-map))
 ;;; Ensure that LEXICAL-LOCATION has an attributed register.  We
 ;;; account for two possibilities.  If LEXICAL-LOCATION already has an
 ;;; attributed register, then we return PREDECESSOR.  If not, we first
@@ -163,7 +164,9 @@
          arrangement lexical-location)
         predecessor
         (let* ((pool (input-pool instruction))
-               (candidates (determine-candidates lexical-location pool))
+               (candidates (x86-64:register-map-difference
+                            (determine-candidates lexical-location pool)
+                            *registers-to-avoid*))
                (new-predecessor
                  (ensure-unattributed-registers
                   predecessor instruction pool candidates 1)))


### PR DESCRIPTION
This PR fixes register allocation for `shift-instruction`, `fixnum-multiply-instruction` and `fixnum-divide-instruction`. Only time can tell if there is some other quirk of x86-64 we haven't handled yet.