### PR TITLE
Avoid relying on host character encodings

### DIFF
--- a/Code/Character/code-char-defun.lisp
+++ b/Code/Character/code-char-defun.lisp
@@ -3,5 +3,5 @@
 (defun code-char (code)
   (check-type code (integer 0 #.(1- char-code-limit)))
   (if (not (<= #xd800 code #xdfff))
-    nil
-    (cleavir-primop:code-char code)))
+    (cleavir-primop:code-char code)
+    nil))


### PR DESCRIPTION
NB. an alternate solution would be to avoid the use of host characters altogether; but that may be more trouble than it is worth.