### PR TITLE
Add Cyclosis to the dependent repo list

### DIFF
--- a/get-dependencies.sh
+++ b/get-dependencies.sh
@@ -12,6 +12,7 @@ https://github.com/s-expressionists/Trucler
 https://github.com/s-expressionists/Clostrum
 https://github.com/s-expressionists/incless
 https://github.com/s-expressionists/ctype
+https://github.com/s-expressionists/Cyclosis
 "
 
 PROJECTS_DIRECTORY=${1:-"$HOME/quicklisp/local-projects/"}


### PR DESCRIPTION
When booting SICL I encountered an error (Component Cyclosis-intrinsic
not found).

Adding the Cyclosis repo to get dependencies and re-running resolved
this issue.

fixes #223 